### PR TITLE
Update install.sh to allow for installation on AMI 2.0

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -12,7 +12,9 @@ FW_BACKEND="nftables"
 API_KEY=""
 
 check_pkg_manager(){
-    if [ -f /etc/redhat-release ] ; then
+    if [ -f /etc/redhat-release ]; then
+        PKG="yum"
+    elif cat /etc/system-release | grep "Amazon Linux release 2 (Karoo)" > /dev/null; then
         PKG="yum"
     elif [ -f /etc/debian_version ]; then
         PKG="apt"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -14,7 +14,7 @@ API_KEY=""
 check_pkg_manager(){
     if [ -f /etc/redhat-release ]; then
         PKG="yum"
-    elif cat /etc/system-release | grep "Amazon Linux release 2 (Karoo)" > /dev/null; then
+    elif cat /etc/system-release | grep -q "Amazon Linux release 2 (Karoo)"; then
         PKG="yum"
     elif [ -f /etc/debian_version ]; then
         PKG="apt"


### PR DESCRIPTION
The install.sh script checks for files such as /etc/redhat-release to determine the package manager to use, but the install script fails the check on Amazon Linux 2 because AWS remove that file and replace it with a /etc/system-release file which contains the AMI release version.

I included a check for the AMI 2.0 file so that it the install script won't fail if users try and run it on AMI 2.0 operating systems.