### PR TITLE
Add pf support

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,4 +112,12 @@ logs can be found in `/var/log/cs-firewall-bouncer.log`
  - mode `nftables` relies on github.com/google/nftables to create table, chain and set.
  - mode `iptables` relies on `iptables` and `ipset` commands to insert `match-set` directives and maintain associated ipsets
  - mode `ipset` relies on `ipset` and only manage contents of the sets (they need to exist at startup and will be flushed rather than created)
- - mode `pf` relies on `pfctl` command to alter the tables.
+ - mode `pf` relies on `pfctl` command to alter the tables. You are required to create the following tables on your `pf.conf` configuration:
+
+ ```
+ # create crowdsec ipv4 table
+table <crowdsec-blacklists> persist
+
+# create crowdsec ipv6 table
+table <crowdsec6-blacklists> persist
+ ```

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Supported firewalls:
  - iptables (IPv4 :heavy_check_mark: / IPv6 :heavy_check_mark: )
  - nftables (IPv4 :heavy_check_mark: / IPv6 :heavy_check_mark: )
  - ipset only (IPv4 :heavy_check_mark: / IPv6 :heavy_check_mark: )
+ - pf (IPV4 :heavy_check_mark: / IPV6 :heavy_check_mark: )
 
 ## Installation
 
@@ -87,7 +88,7 @@ iptables_chains:
   - FORWARD
 ```
 
- - `mode` can be set to `iptables`, `nftables` or `ipset`
+ - `mode` can be set to `iptables`, `nftables` , `ipset` or `pf`
  - `update_frequency` controls how often the bouncer is going to query the local API
  - `api_url` and `api_key` control local API parameters.
  - `iptables_chains` allows (in _iptables_ mode) to control in which chain rules are going to be inserted. (if empty, bouncer will only maintain ipset lists)
@@ -111,3 +112,4 @@ logs can be found in `/var/log/cs-firewall-bouncer.log`
  - mode `nftables` relies on github.com/google/nftables to create table, chain and set.
  - mode `iptables` relies on `iptables` and `ipset` commands to insert `match-set` directives and maintain associated ipsets
  - mode `ipset` relies on `ipset` and only manage contents of the sets (they need to exist at startup and will be flushed rather than created)
+ - mode `pf` relies on `pfctl` command to alter the tables.

--- a/backend.go
+++ b/backend.go
@@ -85,7 +85,7 @@ func newBackend(config *bouncerConfig) (*backendCTX, error) {
 		}
 	case "nftables":
 		if runtime.GOOS != "linux" {
-			return nil, fmt.Errorf("iptables and ipset is linux only")
+			return nil, fmt.Errorf("nftables is linux only")
 		}
 		tmpCtx, err := newNFTables(config)
 		if err != nil {

--- a/backend.go
+++ b/backend.go
@@ -49,6 +49,19 @@ func (b *backendCTX) Delete(decision *models.Decision) error {
 	return nil
 }
 
+func isPFSupported(runtimeOS string) bool {
+	var supported bool
+
+	switch runtimeOS {
+	case "openbsd", "freebsd":
+		supported = true
+	default:
+		supported = false
+	}
+
+	return supported
+}
+
 func newBackend(config *bouncerConfig) (*backendCTX, error) {
 	var ok bool
 
@@ -83,8 +96,8 @@ func newBackend(config *bouncerConfig) (*backendCTX, error) {
 			return nil, fmt.Errorf("unexpected type '%T' for nftables context", tmpCtx)
 		}
 	case "pf":
-		if runtime.GOOS != "openbsd" {
-			return nil, fmt.Errorf("pf is openbsd only")
+		if !isPFSupported(runtime.GOOS) {
+			return nil, fmt.Errorf("pf mode is supported only for openbsd and freebsd")
 		}
 		tmpCtx, err := newPF(config)
 		if err != nil {

--- a/iptables.go
+++ b/iptables.go
@@ -1,3 +1,5 @@
+// +build linux
+
 package main
 
 import (

--- a/iptables_context.go
+++ b/iptables_context.go
@@ -1,3 +1,5 @@
+// +build linux
+
 package main
 
 import (

--- a/iptables_stub.go
+++ b/iptables_stub.go
@@ -1,0 +1,7 @@
+// +build !linux
+
+package main
+
+func newIPTables(config *bouncerConfig) (interface{}, error) {
+	return nil, nil
+}

--- a/nftables.go
+++ b/nftables.go
@@ -1,3 +1,5 @@
+// +build linux
+
 package main
 
 import (

--- a/nftables_stub.go
+++ b/nftables_stub.go
@@ -1,0 +1,7 @@
+// +build !linux
+
+package main
+
+func newNFTables(config *bouncerConfig) (interface{}, error) {
+	return nil, nil
+}

--- a/pf.go
+++ b/pf.go
@@ -1,4 +1,4 @@
-// +build openbsd
+// +build openbsd freebsd
 
 package main
 
@@ -23,7 +23,9 @@ type pf struct {
 	inet6 *pfContext
 }
 
-const PFCTL = "/sbin/pfctl"
+const (
+	pfctlCmd = "/sbin/pfctl"
+)
 
 var pfCtx = &pf{}
 
@@ -54,7 +56,7 @@ func newPF(config *bouncerConfig) (interface{}, error) {
 func (ctx *pfContext) checkTable() error {
 	log.Infof("Checking pf table: %s", ctx.table)
 
-	cmd := exec.Command(PFCTL, "-s", "Tables")
+	cmd := exec.Command(pfctlCmd, "-s", "Tables")
 	out, err := cmd.CombinedOutput()
 
 	if err != nil {
@@ -67,7 +69,7 @@ func (ctx *pfContext) checkTable() error {
 }
 
 func (ctx *pfContext) shutDown() error {
-	cmd := exec.Command(PFCTL, "-t", ctx.table, "-T", "flush")
+	cmd := exec.Command(pfctlCmd, "-t", ctx.table, "-T", "flush")
 	log.Infof("pf table clean-up : %s", cmd.String())
 	if out, err := cmd.CombinedOutput(); err != nil {
 		log.Errorf("Error while flushing table (%s): %v - %s", err, string(out))
@@ -77,7 +79,7 @@ func (ctx *pfContext) shutDown() error {
 
 func (ctx *pfContext) Add(decision *models.Decision) error {
 	log.Debugf("pfctl add ban [%s]", *decision.Value)
-	cmd := exec.Command(PFCTL, "-t", ctx.table, "-T", "add", *decision.Value)
+	cmd := exec.Command(pfctlCmd, "-t", ctx.table, "-T", "add", *decision.Value)
 	log.Debugf("pfctl add : %s", cmd.String())
 	if out, err := cmd.CombinedOutput(); err != nil {
 		log.Infof("Error while adding to table (%s): %v --> %s", cmd.String(), err, string(out))
@@ -87,7 +89,7 @@ func (ctx *pfContext) Add(decision *models.Decision) error {
 
 func (ctx *pfContext) Delete(decision *models.Decision) error {
 	log.Debugf("pfctl del ban for [%s]", *decision.Value)
-	cmd := exec.Command(PFCTL, "-t", ctx.table, "-T", "delete", *decision.Value)
+	cmd := exec.Command(pfctlCmd, "-t", ctx.table, "-T", "delete", *decision.Value)
 	if out, err := cmd.CombinedOutput(); err != nil {
 		log.Infof("Error while deleting from table (%s): %v --> %s", cmd.String(), err, string(out))
 	}

--- a/pf.go
+++ b/pf.go
@@ -1,0 +1,173 @@
+// +build openbsd
+
+package main
+
+import (
+	"fmt"
+	"os/exec"
+	"strings"
+
+	"github.com/pkg/errors"
+	"github.com/crowdsecurity/crowdsec/pkg/models"
+
+	log "github.com/sirupsen/logrus"
+)
+
+type pfContext struct {
+        proto  string
+        table  string
+}
+
+type pf struct {
+	inet  *pfContext
+	inet6 *pfContext
+}
+
+const PFCTL = "/sbin/pfctl"
+
+var pfCtx = &pf{}
+
+func newPF(config *bouncerConfig) (interface{}, error) {
+	ret := &pf{}
+
+	inetCtx := &pfContext{
+		table: "crowdsec-blacklists",
+		proto: "inet",
+	}
+
+	inet6Ctx := &pfContext{
+		table: "crowdsec6-blacklists",
+		proto: "inet6",
+	}
+
+	ret.inet = inetCtx
+
+	if config.DisableIPV6 {
+		return ret, nil
+	}
+
+	ret.inet6 = inet6Ctx
+
+	return ret, nil
+}
+
+func (ctx *pfContext) checkTable() error {
+	log.Infof("Checking pf table: %s", ctx.table)
+
+	cmd := exec.Command(PFCTL, "-s", "Tables")
+	out, err := cmd.CombinedOutput()
+
+	if err != nil {
+		return errors.Wrapf(err, "pfctl error : %v - %s", err, string(out))
+	} else if !strings.Contains(string(out), ctx.table) {
+		return errors.Errorf("table %s doesn't exist", ctx.table)
+	}
+
+	return nil
+}
+
+func (ctx *pfContext) shutDown() error {
+	cmd := exec.Command(PFCTL, "-t", ctx.table, "-T", "flush")
+	log.Infof("pf table clean-up : %s", cmd.String())
+	if out, err := cmd.CombinedOutput(); err != nil {
+		log.Errorf("Error while flushing table (%s): %v - %s", err, string(out))
+	}
+	return nil
+}
+
+func (ctx *pfContext) Add(decision *models.Decision) error {
+	log.Debugf("pfctl add ban [%s]", *decision.Value)
+	cmd := exec.Command(PFCTL, "-t", ctx.table, "-T", "add", *decision.Value)
+	log.Debugf("pfctl add : %s", cmd.String())
+	if out, err := cmd.CombinedOutput(); err != nil {
+		log.Infof("Error while adding to table (%s): %v --> %s", cmd.String(), err, string(out))
+	}
+	return nil
+}
+
+func (ctx *pfContext) Delete(decision *models.Decision) error {
+	log.Debugf("pfctl del ban for [%s]", *decision.Value)
+	cmd := exec.Command(PFCTL, "-t", ctx.table, "-T", "delete", *decision.Value)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		log.Infof("Error while deleting from table (%s): %v --> %s", cmd.String(), err, string(out))
+	}
+	return nil
+}
+
+func (pf *pf) Init() error {
+	var err error
+
+	if err := pf.inet.shutDown(); err != nil {
+		return fmt.Errorf("pf table flush failed: %s", err.Error())
+	}
+	if err := pf.inet.checkTable(); err != nil {
+		return fmt.Errorf("pf init failed: %s", err.Error())
+	}
+	log.Printf("pf for ipv4 initiated")
+
+	if pf.inet6 != nil {
+		if err = pf.inet.shutDown(); err != nil {
+			return fmt.Errorf("pf shutdown failed: %s", err.Error())
+		}
+		if err := pf.inet.checkTable(); err != nil {
+			return fmt.Errorf("pf init failed: %s", err.Error())
+		}
+		log.Printf("pf for ipv6 initiated")
+	}
+
+	return nil
+}
+
+func (pf *pf) Add(decision *models.Decision) error {
+	if strings.Contains(*decision.Value, ":") && pf.inet6 != nil { // inet6
+		if pf.inet6 != nil {
+			if err := pf.inet6.Add(decision); err != nil {
+				return fmt.Errorf("failed to add ban ip '%s' to inet6 table", *decision.Value)
+			}
+		} else {
+			log.Debugf("not adding '%s' because ipv6 is disabled", *decision.Value)
+			return nil
+		}
+	} else { // inet
+		if err := pf.inet.Add(decision); err != nil {
+				return fmt.Errorf("failed adding ban ip '%s' to inet table", *decision.Value)
+		}
+	}
+
+	return nil
+}
+
+func (pf *pf) Delete(decision *models.Decision) error {
+	if strings.Contains(*decision.Value, ":") { // ipv6
+		if pf.inet6 != nil {
+			if err := pf.inet6.Delete(decision); err != nil {
+				return fmt.Errorf("failed to remove ban ip '%s' from inet6 table", *decision.Value)
+			}
+		} else {
+			log.Debugf("not removing '%s' because ipv6 is disabled", *decision.Value)
+			return nil
+		}
+	} else { // ipv4
+		if err := pf.inet.Delete(decision); err != nil {
+			return fmt.Errorf("failed to remove ban ip '%s' from inet6 table", *decision.Value)
+		}
+	}
+
+	return nil
+}
+
+func (pf *pf) ShutDown() error {
+	log.Infof("flushing 'crowdsec' table(s)")
+
+	if err := pf.inet.shutDown(); err != nil {
+		return fmt.Errorf("unable to flush inet table (%s): ", pf.inet.table)
+	}
+
+	if pf.inet6 != nil {
+		if err := pf.inet6.shutDown(); err != nil {
+			return fmt.Errorf("unable to flush inet table (%s): ", pf.inet.table)
+		}
+	}
+
+	return nil
+}

--- a/pf.go
+++ b/pf.go
@@ -4,6 +4,7 @@ package main
 
 import (
 	"fmt"
+	"os"
 	"os/exec"
 	"strings"
 
@@ -25,6 +26,7 @@ type pf struct {
 
 const (
 	pfctlCmd = "/sbin/pfctl"
+	pfDevice = "/dev/pf"
 )
 
 var pfCtx = &pf{}
@@ -98,6 +100,14 @@ func (ctx *pfContext) Delete(decision *models.Decision) error {
 
 func (pf *pf) Init() error {
 	var err error
+
+	if _, err := os.Stat(pfDevice); err != nil {
+		return fmt.Errorf("%s device not found: %s", pfDevice, err.Error())
+	}
+
+	if _, err := exec.LookPath(pfctlCmd); err != nil {
+		return fmt.Errorf("%s command not found: %s", pfctlCmd, err.Error())
+	}
 
 	if err := pf.inet.shutDown(); err != nil {
 		return fmt.Errorf("pf table flush failed: %s", err.Error())

--- a/pf_stub.go
+++ b/pf_stub.go
@@ -1,0 +1,7 @@
+// +build !openbsd
+
+package main
+
+func newPF(config *bouncerConfig) (interface{}, error) {
+	return nil, nil
+}

--- a/pf_stub.go
+++ b/pf_stub.go
@@ -1,4 +1,4 @@
-// +build !openbsd
+// +build !openbsd,!freebsd
 
 package main
 


### PR DESCRIPTION
This commit add the [packet filter firewall](https://en.wikipedia.org/wiki/PF_(firewall)) backend support as mode `pf` for `cs-firewall-bouncer` working on `OpenBSD` and `FreeBSD` and tested.

* It contains initial OpenBSD support by @rnagy on #36 
* FreeBSD, improvement log durations, ipv6 fixes, cleanup and documentation by @sbz
* Tested for both `ipv4` and `ipv6`

After configuring [config/cs-firewall-bouncer.yaml](config/config/cs-firewall-bouncer.yaml) with `mode: pf` and running the bouncer, we are correctly seeing the new decisions added using `pfctl(8)` command

```
$ sudo tail -n0 -f /var/log/cs-firewall-bouncer.log
time="12-04-2021 14:39:51" level=info msg="backend type : pf"
time="12-04-2021 14:39:51" level=info msg="pf table clean-up : /sbin/pfctl -t crowdsec-blacklists -T flush"
time="12-04-2021 14:39:51" level=info msg="Checking pf table: crowdsec-blacklists"
time="12-04-2021 14:39:51" level=info msg="pf initiated for ipv4"
time="12-04-2021 14:39:51" level=info msg="pf table clean-up : /sbin/pfctl -t crowdsec6-blacklists -T flush"
time="12-04-2021 14:39:51" level=info msg="Checking pf table: crowdsec6-blacklists"
time="12-04-2021 14:39:51" level=info msg="pf initiated for ipv6"
time="12-04-2021 14:39:51" level=info msg="Processing new and deleted decisions . . ."
time="12-04-2021 14:39:52" level=info msg="deleting '5000' decisions"
time="12-04-2021 14:40:00" level=info msg="adding '1200' decisions"
```