### PR TITLE
Add -V flag to display bouncer version

### DIFF
--- a/main.go
+++ b/main.go
@@ -56,11 +56,18 @@ func HandleSignals(backend *backendCTX) {
 
 func main() {
 	var err error
-	log.Infof("cs-firewall-bouncer %s", version.VersionStr())
 	configPath := flag.String("c", "", "path to cs-firewall-bouncer.yaml")
 	verbose := flag.Bool("v", false, "set verbose mode")
+	bouncerVersion := flag.Bool("V", false, "display version and exit")
 
 	flag.Parse()
+
+	if *bouncerVersion {
+		fmt.Printf("%s", version.ShowStr())
+		os.Exit(0)
+	}
+
+	log.Infof("cs-firewall-bouncer %s", version.VersionStr())
 
 	if configPath == nil || *configPath == "" {
 		log.Fatalf("configuration file is required")


### PR DESCRIPTION
Display version and exit, also move down the call to log.Info() to avoid
showing the log line when using new -V flag.