### PR TITLE
Fix pf log message format while flushing and add missing argument

### DIFF
--- a/pf.go
+++ b/pf.go
@@ -85,7 +85,7 @@ func (ctx *pfContext) shutDown() error {
 	cmd := exec.Command(pfctlCmd, "-t", ctx.table, "-T", "flush")
 	log.Infof("pf table clean-up : %s", cmd.String())
 	if out, err := cmd.CombinedOutput(); err != nil {
-		log.Errorf("Error while flushing table (%s): %v - %s", err, string(out))
+		log.Errorf("Error while flushing table (%s): %v --> %s", cmd.String(), err, string(out))
 	}
 
 	return nil


### PR DESCRIPTION
It was reported by go test while executing the `test` target.

```
$ gmake -f Makefile
./pf.go:88:3: Errorf format %s reads arg #3, but call has 2 args
gmake: *** [Makefile:41: test] Error 2
```