### PR TITLE
Rpm packaging

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ BINARY_NAME=crowdsec-firewall-bouncer
 
 RELDIR = "crowdsec-firewall-bouncer-${BUILD_VERSION}"
 
-all: clean test build
+all: clean build
 
 goversion:
 	CURRENT_GOVERSION="$(shell go version | cut -d " " -f3 | sed -r 's/[go]+//g')"
@@ -61,4 +61,4 @@ release: build
 	@chmod +x $(RELDIR)/uninstall.sh
 	@chmod +x $(RELDIR)/upgrade.sh
 	@tar cvzf crowdsec-firewall-bouncer.tgz $(RELDIR)
-	
+

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ BINARY_NAME=crowdsec-firewall-bouncer
 
 RELDIR = "crowdsec-firewall-bouncer-${BUILD_VERSION}"
 
-all: clean build
+all: clean test build
 
 goversion:
 	CURRENT_GOVERSION="$(shell go version | cut -d " " -f3 | sed -r 's/[go]+//g')"

--- a/rpm/SPECS/crowdsec-firewall-bouncer.spec
+++ b/rpm/SPECS/crowdsec-firewall-bouncer.spec
@@ -31,7 +31,10 @@ Requires: iptables,ipset,gettext
 
 %build
 BUILD_VERSION=%{local_version} make
-BIN=%{buildroot}%{_bindir}/%{name} CFG=/etc/crowdsec/ envsubst < config/%{name}.service | tee config/%{name}.service
+TMP=`mktemp -p /tmp/`
+cp config/%{name}.service ${TMP}
+BIN=%{buildroot}%{_bindir}/%{name} CFG=/etc/crowdsec/ envsubst < ${TMP}/%{name}.service > config/%{name}.service
+rm -rf  ${TMP}
 
 %install
 rm -rf %{buildroot}

--- a/rpm/SPECS/crowdsec-firewall-bouncer.spec
+++ b/rpm/SPECS/crowdsec-firewall-bouncer.spec
@@ -8,10 +8,10 @@ URL:            https://crowdsec.net
 Source0:        https://github.com/crowdsecurity/%{name}/archive/v%(echo $VERSION).tar.gz
 BuildRoot:      %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 
-BuildRequires:  git
-BuildRequires:  golang >= 1.14
-BuildRequires:  make
-BuildRequires:  jq
+#BuildRequires:  git
+#BuildRequires:  golang >= 1.14
+#BuildRequires:  make
+#BuildRequires:  jq
 %{?fc33:BuildRequires: systemd-rpm-macros}
 
 Requires: iptables,ipset,gettext
@@ -27,7 +27,7 @@ Requires: iptables,ipset,gettext
 %global __mangle_shebangs_exclude_from /usr/bin/env
 
 %prep
-%setup -q -T -b 0
+%setup -q -T -b 0 -n crowdsec-firewall-bouncer-%{version_number}
 
 %build
 BUILD_VERSION=%{local_version} make

--- a/rpm/SPECS/crowdsec-firewall-bouncer.spec
+++ b/rpm/SPECS/crowdsec-firewall-bouncer.spec
@@ -8,10 +8,10 @@ URL:            https://crowdsec.net
 Source0:        https://github.com/crowdsecurity/%{name}/archive/v%(echo $VERSION).tar.gz
 BuildRoot:      %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 
-#BuildRequires:  git
-#BuildRequires:  golang >= 1.14
-#BuildRequires:  make
-#BuildRequires:  jq
+BuildRequires:  git
+BuildRequires:  golang >= 1.14
+BuildRequires:  make
+BuildRequires:  jq
 %{?fc33:BuildRequires: systemd-rpm-macros}
 
 Requires: (crowdsec-firewall-bouncer-iptables or crowdsec-firewall-bouncer-nftables)

--- a/rpm/SPECS/crowdsec-firewall-bouncer.spec
+++ b/rpm/SPECS/crowdsec-firewall-bouncer.spec
@@ -31,6 +31,7 @@ Requires: iptables,ipset,gettext
 
 %build
 BUILD_VERSION=%{local_version} make
+BIN=%{buildroot}%{_bindir}/%{name} CFG=/etc/crowdsec/ envsubst < config/%{name}.service | tee config/%{name}.service
 
 %install
 rm -rf %{buildroot}

--- a/rpm/SPECS/crowdsec-firewall-bouncer.spec
+++ b/rpm/SPECS/crowdsec-firewall-bouncer.spec
@@ -8,10 +8,10 @@ URL:            https://crowdsec.net
 Source0:        https://github.com/crowdsecurity/%{name}/archive/v%(echo $VERSION).tar.gz
 BuildRoot:      %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 
-#BuildRequires:  git
-#BuildRequires:  golang >= 1.14
-#BuildRequires:  make
-#BuildRequires:  jq
+BuildRequires:  git
+BuildRequires:  golang >= 1.14
+BuildRequires:  make
+BuildRequires:  jq
 %{?fc33:BuildRequires: systemd-rpm-macros}
 
 Requires: iptables,ipset,gettext

--- a/rpm/SPECS/crowdsec-firewall-bouncer.spec
+++ b/rpm/SPECS/crowdsec-firewall-bouncer.spec
@@ -47,6 +47,7 @@ rm -rf %{buildroot}
 %files
 %defattr(-,root,root,-)
 /usr/bin/%{name}
+%{_unitdir}/%{name}.service
 
 
 %post -p /bin/bash

--- a/rpm/SPECS/crowdsec-firewall-bouncer.spec
+++ b/rpm/SPECS/crowdsec-firewall-bouncer.spec
@@ -33,7 +33,7 @@ Requires: iptables,ipset,gettext
 BUILD_VERSION=%{local_version} make
 TMP=`mktemp -p /tmp/`
 cp config/%{name}.service ${TMP}
-BIN=%{buildroot}%{_bindir}/%{name} CFG=/etc/crowdsec/ envsubst < ${TMP} > config/%{name}.service
+BIN=%{_bindir}/%{name} CFG=/etc/crowdsec/ envsubst < ${TMP} > config/%{name}.service
 rm ${TMP}
 
 %install

--- a/rpm/SPECS/crowdsec-firewall-bouncer.spec
+++ b/rpm/SPECS/crowdsec-firewall-bouncer.spec
@@ -1,0 +1,149 @@
+Name:           crowdsec-firewall-bouncer
+Version:        %(echo $VERSION)
+Release:        %(echo $PACKAGE_NUMBER)%{?dist}
+Summary:      Firewall bouncer for Crowdsec (iptables+ipset, nftables or pf)
+
+License:        MIT
+URL:            https://crowdsec.net
+Source0:        https://github.com/crowdsecurity/%{name}/archive/v%(echo $VERSION).tar.gz
+BuildRoot:      %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
+
+#BuildRequires:  git
+#BuildRequires:  golang >= 1.14
+#BuildRequires:  make
+#BuildRequires:  jq
+%{?fc33:BuildRequires: systemd-rpm-macros}
+
+Requires: (crowdsec-firewall-bouncer-iptables or crowdsec-firewall-bouncer-nftables)
+
+%define debug_package %{nil}
+
+%description
+
+%define version_number  %(echo $VERSION)
+%define releasever  %(echo $RELEASEVER)
+%global local_version v%{version_number}-%{releasever}-rpm
+%global name crowdsec-firewall-bouncer
+%global __mangle_shebangs_exclude_from /usr/bin/env
+
+%prep
+%setup -q -T -b 0
+
+%build
+BUILD_VERSION=%{local_version} make
+
+%install
+rm -rf %{buildroot}
+mkdir -p %{buildroot}/usr/sbin
+install -m 755 -D %{name}  %{buildroot}%{_bindir}/%{name}
+install -m 600 -D config/%{name}.yaml %{buildroot}/etc/crowdsec/%{name}.yaml 
+install -m 644 -D config/%{name}.service %{buildroot}%{_unitdir}/%{name}.service
+#install -m 644 -D config/patterns/* -t %{buildroot}%{_sysconfdir}/crowdsec/patterns
+#install -m 644 -D config/config.yaml %{buildroot}%{_sysconfdir}/crowdsec
+
+%clean
+rm -rf %{buildroot}
+
+%files
+%defattr(-,root,root,-)
+/usr/bin/%{name}
+
+
+%post -p /bin/bash
+
+
+
+ 
+%changelog
+* Tue Feb 16 2021 Manuel Sabban <manuel@crowdsec.net>
+- First initial packaging
+
+%preun
+systemctl stop crowdsec-firewall-bouncer || echo "cannot stop service"
+systemctl disable crowdsec-firewall-bouncer || echo "cannot disable service"
+
+%package iptables
+Summary:      Firewall bouncer for Crowdsec (iptables configuration)
+Requires: iptables,ipset,gettext
+%description iptables
+
+%files iptables
+/etc/crowdsec/%{name}.yaml 
+
+%package nftables
+Summary:      Firewall bouncer for Crowdsec (nftables configuration)
+Requires: nftables,gettext
+%description nftables
+
+%files nftables
+/etc/crowdsec/%{name}.yaml 
+
+%post -p /bin/bash iptables
+
+systemctl daemon-reload
+
+
+START=0
+
+rpm -q crowdsec | grep -q ^ii >/dev/null
+
+if [ "$?" -eq "0" ] ; then
+    START=1
+    echo "cscli/crowdsec is present, generating API key"
+    unique=`date +%s`
+    API_KEY=`cscli -oraw bouncers add FirewallBouncer-${unique}`
+    if [ $? -eq 1 ] ; then
+        echo "failed to create API token, service won't be started."
+        START=0
+        API_KEY="<API_KEY>"
+    else
+        echo "API Key : ${API_KEY}"
+    fi
+fi
+
+TMP=`mktemp -p /tmp/`
+cp /etc/crowdsec/crowdsec-firewall-bouncer.yaml ${TMP}
+BACKEND=iptables API_KEY=${API_KEY} envsubst < ${TMP} > /etc/crowdsec/crowdsec-firewall-bouncer.yaml
+rm ${TMP}
+
+if [ ${START} -eq 0 ] ; then
+    echo "no api key was generated, won't start service"
+else 
+    systemctl start crowdsec-firewall-bouncer
+fi
+
+
+%post -p /bin/bash nftables
+
+systemctl daemon-reload
+
+
+START=0
+
+rpm -q crowdsec | grep -q ^ii >/dev/null
+
+if [ "$?" -eq "0" ] ; then
+    START=1
+    echo "cscli/crowdsec is present, generating API key"
+    unique=`date +%s`
+    API_KEY=`cscli -oraw bouncers add FirewallBouncer-${unique}`
+    if [ $? -eq 1 ] ; then
+        echo "failed to create API token, service won't be started."
+        START=0
+        API_KEY="<API_KEY>"
+    else
+        echo "API Key : ${API_KEY}"
+    fi
+fi
+
+TMP=`mktemp -p /tmp/`
+cp /etc/crowdsec/crowdsec-firewall-bouncer.yaml ${TMP}
+BACKEND=nftables API_KEY=${API_KEY} envsubst < ${TMP} > /etc/crowdsec/crowdsec-firewall-bouncer.yaml
+rm ${TMP}
+
+if [ ${START} -eq 0 ] ; then
+    echo "no api key was generated, won't start service"
+else 
+    systemctl start crowdsec-firewall-bouncer
+fi
+

--- a/rpm/SPECS/crowdsec-firewall-bouncer.spec
+++ b/rpm/SPECS/crowdsec-firewall-bouncer.spec
@@ -33,8 +33,8 @@ Requires: iptables,ipset,gettext
 BUILD_VERSION=%{local_version} make
 TMP=`mktemp -p /tmp/`
 cp config/%{name}.service ${TMP}
-BIN=%{buildroot}%{_bindir}/%{name} CFG=/etc/crowdsec/ envsubst < ${TMP}/%{name}.service > config/%{name}.service
-rm -rf  ${TMP}
+BIN=%{buildroot}%{_bindir}/%{name} CFG=/etc/crowdsec/ envsubst < ${TMP} > config/%{name}.service
+rm ${TMP}
 
 %install
 rm -rf %{buildroot}


### PR DESCRIPTION
Add RPM packaging.
This a bit different than for debian: we only have 2 packages, crowdsec-firewall-bouncer-iptables and  crowdsec-firewall-bouncer-nftables due to some version of centos not supporting boolean requirements.