### PR TITLE
Multiple fixes

### DIFF
--- a/.github/workflows/build-binary-package.yml
+++ b/.github/workflows/build-binary-package.yml
@@ -22,6 +22,6 @@ jobs:
     - name: Upload to release
       uses: JasonEtco/upload-to-release@master
       with:
-        args: cs-firewall-bouncer.tgz application/x-gzip
+        args: crowdsec-firewall-bouncer.tgz application/x-gzip
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Supported firewalls:
 First, download the latest [`cs-firewall-bouncer` release](https://github.com/crowdsecurity/cs-firewall-bouncer/releases).
 
 ```sh
-$ tar xzvf cs-firewall-bouncer.tgz
+$ tar xzvf crowdsec-firewall-bouncer.tgz
 $ sudo ./install.sh
 ```
 
@@ -42,7 +42,7 @@ Run the following commands:
 git clone https://github.com/crowdsecurity/cs-firewall-bouncer.git
 cd cs-firewall-bouncer/
 make release
-tar xzvf cs-firewall-bouncer.tgz
+tar xzvf crowdsec-firewall-bouncer.tgz
 cd cs-firewall-bouncer-v*/
 sudo ./install.sh
 ```
@@ -52,8 +52,8 @@ sudo ./install.sh
 If you already have `cs-firewall-bouncer` installed, please download the [latest release](https://github.com/crowdsecurity/cs-firewall-bouncer/releases) and run the following commands:
 
 ```bash
-tar xzvf cs-firewall-bouncer.tgz
-cd cs-firewall-bouncer-v*/
+tar xzvf crowdsec-firewall-bouncer.tgz
+cd crowdsec-firewall-bouncer-v*/
 sudo ./upgrade.sh
 ```
 
@@ -65,7 +65,7 @@ The `install.sh` script will take care of it (it will call `cscli bouncers add` 
 If it was not the case, the default configuration file is located under : `/etc/crowdsec/cs-firewall-bouncer/`
 
 ```sh
-$ vim /etc/crowdsec/cs-firewall-bouncer/cs-firewall-bouncer.yaml
+$ vim /etc/crowdsec/crowdsec-firewall-bouncer/crowdsec-firewall-bouncer.yaml
 ```
 
 ```yaml
@@ -105,7 +105,7 @@ sudo systemctl start cs-firewall-bouncer
 
 ### logs
 
-logs can be found in `/var/log/cs-firewall-bouncer.log`
+logs can be found in `/var/log/crowdsec-firewall-bouncer.log`
 
 ### modes
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,17 @@ Supported firewalls:
  - ipset only (IPv4 :heavy_check_mark: / IPv6 :heavy_check_mark: )
  - pf (IPV4 :heavy_check_mark: / IPV6 :heavy_check_mark: )
 
-## Installation
+# Installation
+
+## Using packages
+
+Packages for crowdsec-firewall-bouncer [are available on our repositories](https://doc.crowdsec.net/Crowdsec/v1/getting_started/installation/#installation-methods).
+
+ - debian/ubuntu : `apt install crowdsec-firewall-bouncer`
+ - rhel/centos/fedora : `yum install crowdsec-firewall-bouncer`
+ - freebsd : `pkg install crowdsec-firewall-bouncer`
+
+## Manual installation
 
 ### Assisted
 

--- a/README.md
+++ b/README.md
@@ -12,10 +12,10 @@
 </p>
 
 
-# cs-firewall-bouncer
+# crowdsec-firewall-bouncer
 Crowdsec bouncer written in golang for firewalls.
 
-cs-firewall-bouncer will fetch new and old decisions from a CrowdSec API to add them in a blocklist used by supported firewalls.
+crowdsec-firewall-bouncer will fetch new and old decisions from a CrowdSec API to add them in a blocklist used by supported firewalls.
 
 Supported firewalls:
  - iptables (IPv4 :heavy_check_mark: / IPv6 :heavy_check_mark: )
@@ -27,7 +27,7 @@ Supported firewalls:
 
 ### Assisted
 
-First, download the latest [`cs-firewall-bouncer` release](https://github.com/crowdsecurity/cs-firewall-bouncer/releases).
+First, download the latest [`crowdsec-firewall-bouncer` release](https://github.com/crowdsecurity/cs-firewall-bouncer/releases).
 
 ```sh
 $ tar xzvf crowdsec-firewall-bouncer.tgz
@@ -43,13 +43,13 @@ git clone https://github.com/crowdsecurity/cs-firewall-bouncer.git
 cd cs-firewall-bouncer/
 make release
 tar xzvf crowdsec-firewall-bouncer.tgz
-cd cs-firewall-bouncer-v*/
+cd crowdsec-firewall-bouncer-v*/
 sudo ./install.sh
 ```
 
 ## Upgrade
 
-If you already have `cs-firewall-bouncer` installed, please download the [latest release](https://github.com/crowdsecurity/cs-firewall-bouncer/releases) and run the following commands:
+If you already have `crowdsec-firewall-bouncer` installed, please download the [latest release](https://github.com/crowdsecurity/cs-firewall-bouncer/releases) and run the following commands:
 
 ```bash
 tar xzvf crowdsec-firewall-bouncer.tgz
@@ -60,12 +60,12 @@ sudo ./upgrade.sh
 
 ## Configuration
 
-To be functional, the `cs-firewall-bouncer` service must be able to authenticate with the local API.
+To be functional, the `crowdsec-firewall-bouncer` service must be able to authenticate with the local API.
 The `install.sh` script will take care of it (it will call `cscli bouncers add` on your behalf).
-If it was not the case, the default configuration file is located under : `/etc/crowdsec/cs-firewall-bouncer/`
+If it was not the case, the default configuration file is located under : `/etc/crowdsec/crowdsec-firewall-bouncer.yaml`
 
 ```sh
-$ vim /etc/crowdsec/crowdsec-firewall-bouncer/crowdsec-firewall-bouncer.yaml
+$ vim /etc/crowdsec/crowdsec-firewall-bouncer.yaml
 ```
 
 ```yaml
@@ -100,7 +100,7 @@ iptables_chains:
 You can then start the service:
 
 ```sh
-sudo systemctl start cs-firewall-bouncer
+sudo systemctl start crowdsec-firewall-bouncer
 ```
 
 ### logs

--- a/config.go
+++ b/config.go
@@ -64,7 +64,7 @@ func NewConfig(configPath string) (*bouncerConfig, error) {
 			config.LogDir = "/var/log/"
 		}
 		LogOutput = &lumberjack.Logger{
-			Filename:   config.LogDir + "/cs-firewall-bouncer.log",
+			Filename:   config.LogDir + "/crowdsec-firewall-bouncer.log",
 			MaxSize:    500, //megabytes
 			MaxBackups: 3,
 			MaxAge:     28,   //days

--- a/debian/control
+++ b/debian/control
@@ -4,7 +4,7 @@ Build-Depends: debhelper, jq, bash, git
 
 
 Package: crowdsec-firewall-bouncer
-Depends: crowdsec-firewall-bouncer-iptables | crowdsec-firewall-bouncer-nftables
+Depends: crowdsec-firewall-bouncer-nftables | crowdsec-firewall-bouncer-iptables
 Provides: crowdsec-firewall-bouncer
 Description: Firewall bouncer for Crowdsec (iptables+ipset, nftables or pf)
 Architecture: any

--- a/main.go
+++ b/main.go
@@ -56,7 +56,7 @@ func HandleSignals(backend *backendCTX) {
 
 func main() {
 	var err error
-	configPath := flag.String("c", "", "path to cs-firewall-bouncer.yaml")
+	configPath := flag.String("c", "", "path to crowdsec-firewall-bouncer.yaml")
 	verbose := flag.Bool("v", false, "set verbose mode")
 	bouncerVersion := flag.Bool("V", false, "display version and exit")
 

--- a/main.go
+++ b/main.go
@@ -17,7 +17,7 @@ import (
 )
 
 const (
-	name = "cs-firewall-bouncer"
+	name = "crowdsec-firewall-bouncer"
 )
 
 var t tomb.Tomb
@@ -67,7 +67,7 @@ func main() {
 		os.Exit(0)
 	}
 
-	log.Infof("cs-firewall-bouncer %s", version.VersionStr())
+	log.Infof("crowdsec-firewall-bouncer %s", version.VersionStr())
 
 	if configPath == nil || *configPath == "" {
 		log.Fatalf("configuration file is required")

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
-BIN_PATH_INSTALLED="/usr/local/bin/cs-firewall-bouncer"
-BIN_PATH="./cs-firewall-bouncer"
-CONFIG_DIR="/etc/crowdsec/cs-firewall-bouncer/"
+BIN_PATH_INSTALLED="/usr/local/bin/crowdsec-firewall-bouncer"
+BIN_PATH="./crowdsec-firewall-bouncer"
+CONFIG_DIR="/etc/crowdsec/"
 PID_DIR="/var/run/crowdsec/"
 SYSTEMD_PATH_FILE="/etc/systemd/system/crowdsec-firewall-bouncer.service"
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -3,7 +3,7 @@ BIN_PATH_INSTALLED="/usr/local/bin/cs-firewall-bouncer"
 BIN_PATH="./cs-firewall-bouncer"
 CONFIG_DIR="/etc/crowdsec/cs-firewall-bouncer/"
 PID_DIR="/var/run/crowdsec/"
-SYSTEMD_PATH_FILE="/etc/systemd/system/cs-firewall-bouncer.service"
+SYSTEMD_PATH_FILE="/etc/systemd/system/crowdsec-firewall-bouncer.service"
 
 # Default pkg manager is apt
 PKG="apt"
@@ -88,7 +88,7 @@ gen_apikey() {
 }
 
 gen_config_file() {
-    API_KEY=${API_KEY} BACKEND=${FW_BACKEND} envsubst < ./config/cs-firewall-bouncer.yaml > "${CONFIG_DIR}cs-firewall-bouncer.yaml"
+    API_KEY=${API_KEY} BACKEND=${FW_BACKEND} envsubst < ./config/crowdsec-firewall-bouncer.yaml > "${CONFIG_DIR}crowdsec-firewall-bouncer.yaml"
 }
 
 check_ipset() {
@@ -111,8 +111,8 @@ check_ipset() {
 install_firewall_bouncer() {
 	install -v -m 755 -D "${BIN_PATH}" "${BIN_PATH_INSTALLED}"
 	mkdir -p "${CONFIG_DIR}"
-	cp "./config/cs-firewall-bouncer.yaml" "${CONFIG_DIR}cs-firewall-bouncer.yaml"
-	CFG=${CONFIG_DIR} PID=${PID_DIR} BIN=${BIN_PATH_INSTALLED} envsubst < ./config/cs-firewall-bouncer.service > "${SYSTEMD_PATH_FILE}"
+	cp "./config/crowdsec-firewall-bouncer.yaml" "${CONFIG_DIR}crowdsec-firewall-bouncer.yaml"
+	CFG=${CONFIG_DIR} PID=${PID_DIR} BIN=${BIN_PATH_INSTALLED} envsubst < ./config/crowdsec-firewall-bouncer.service > "${SYSTEMD_PATH_FILE}"
 	systemctl daemon-reload
 }
 
@@ -128,10 +128,10 @@ echo "Installing firewall-bouncer"
 install_firewall_bouncer
 gen_apikey
 gen_config_file
-systemctl enable cs-firewall-bouncer.service
+systemctl enable crowdsec-firewall-bouncer.service
 if [ "$READY" = "yes" ]; then
-    systemctl start cs-firewall-bouncer.service
+    systemctl start crowdsec-firewall-bouncer.service
 else
-    echo "service not started. You need to get an API key and configure it in ${CONFIG_DIR}cs-firewall-bouncer.yaml"
+    echo "service not started. You need to get an API key and configure it in ${CONFIG_DIR}crowdsec-firewall-bouncer.yaml"
 fi
 echo "The firewall-bouncer service has been installed!"

--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -1,12 +1,12 @@
 #!/bin/bash
 
-BIN_PATH_INSTALLED="/usr/local/bin/cs-firewall-bouncer"
-CONFIG_DIR="/etc/crowdsec/cs-firewall-bouncer/"
+BIN_PATH_INSTALLED="/usr/local/bin/crowdsec-firewall-bouncer"
+CONFIG_DIR="/etc/crowdsec/crowdsec-firewall-bouncer/"
 LOG_FILE="/var/log/crowdsec-firewall-bouncer.log"
 SYSTEMD_PATH_FILE="/etc/systemd/system/crowdsec-firewall-bouncer.service"
 
 uninstall() {
-	systemctl stop cs-firewall-bouncer
+	systemctl stop crowdsec-firewall-bouncer
 	rm -rf "${CONFIG_DIR}"
 	rm -f "${SYSTEMD_PATH_FILE}"
 	rm -f "${BIN_PATH_INSTALLED}"
@@ -15,4 +15,4 @@ uninstall() {
 
 uninstall
 
-echo "cs-firewall-bouncer uninstall successfully"
+echo "crowdsec-firewall-bouncer uninstall successfully"

--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 BIN_PATH_INSTALLED="/usr/local/bin/crowdsec-firewall-bouncer"
-CONFIG_DIR="/etc/crowdsec/crowdsec-firewall-bouncer/"
+CONFIG_DIR="/etc/crowdsec/crowdsec-firewall-bouncer.yaml"
 LOG_FILE="/var/log/crowdsec-firewall-bouncer.log"
 SYSTEMD_PATH_FILE="/etc/systemd/system/crowdsec-firewall-bouncer.service"
 

--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -2,8 +2,8 @@
 
 BIN_PATH_INSTALLED="/usr/local/bin/cs-firewall-bouncer"
 CONFIG_DIR="/etc/crowdsec/cs-firewall-bouncer/"
-LOG_FILE="/var/log/cs-firewall-bouncer.log"
-SYSTEMD_PATH_FILE="/etc/systemd/system/cs-firewall-bouncer.service"
+LOG_FILE="/var/log/crowdsec-firewall-bouncer.log"
+SYSTEMD_PATH_FILE="/etc/systemd/system/crowdsec-firewall-bouncer.service"
 
 uninstall() {
 	systemctl stop cs-firewall-bouncer

--- a/scripts/upgrade.sh
+++ b/scripts/upgrade.sh
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
-BIN_PATH_INSTALLED="/usr/local/bin/cs-firewall-bouncer"
-BIN_PATH="./cs-firewall-bouncer"
+BIN_PATH_INSTALLED="/usr/local/bin/crowdsec-firewall-bouncer"
+BIN_PATH="./crowdsec-firewall-bouncer"
 
 
 upgrade_bin() {
-    rm "${BIN_PATH_INSTALLED}" || (echo "cs-firewall-bouncer is not installed, exiting." && exit 1)
+    rm "${BIN_PATH_INSTALLED}" || (echo "crowdsec-firewall-bouncer is not installed, exiting." && exit 1)
     install -v -m 755 -D "${BIN_PATH}" "${BIN_PATH_INSTALLED}"
 }
 
@@ -14,7 +14,7 @@ if ! [ $(id -u) = 0 ]; then
     exit 1
 fi
 
-systemctl stop cs-firewall-bouncer
+systemctl stop crowdsec-firewall-bouncer
 upgrade_bin
-systemctl start cs-firewall-bouncer
-echo "cs-firewall-bouncer upgraded successfully."
+systemctl start crowdsec-firewall-bouncer
+echo "crowdsec-firewall-bouncer upgraded successfully."


### PR DESCRIPTION
 - unify everything to `crowdsec-firewall-bouncer` rather than `cs-firewall-bouncer` (install script was still referring the old name)
 - document availability of deb/rpm packages
 - unify log paths and configuration path
