### PR TITLE
make crowdsec-firewall-bouncer depend on -nftables or -iptables

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -13,10 +13,11 @@ Architecture: any
 Package: crowdsec-firewall-bouncer-iptables
 Architecture: any
 Description: Firewall bouncer for Crowdsec (iptables+ipset)
-Depends: iptables, ipset
+Depends: iptables, ipset, crowdsec-firewall-bouncer (=${binary:Version})
 
 Package: crowdsec-firewall-bouncer-nftables
 Architecture: any
 Description: Firewall bouncer for Crowdsec (nftables)
-Depends: nftables
+Depends: nftables, crowdsec-firewall-bouncer (=${binary:Version})
+
 


### PR DESCRIPTION
and the other way around, so to fix #61 
