### PR TITLE
Fix deny_log usage

### DIFF
--- a/iptables.go
+++ b/iptables.go
@@ -88,12 +88,12 @@ func newIPTables(config *bouncerConfig) (interface{}, error) {
 		}
 		for _, v := range config.IptablesChains {
 			if config.DenyLog {
-				ipv6Ctx.StartupCmds = append(ipv4Ctx.StartupCmds,
-				[]string{"-I", v, "-m", "set", "--match-set", "crowdsec6-blacklists", "src", "--log-prefix", config.DenyLogPrefix, "-j", "LOG"})
-				ipv6Ctx.ShutdownCmds = append(ipv4Ctx.ShutdownCmds,
-				[]string{"-D", v, "-m", "set", "--match-set", "crowdsec6-blacklists", "src", "--log-prefix", config.DenyLogPrefix, "-j", "LOG"})
-				ipv6Ctx.CheckIptableCmds = append(ipv4Ctx.CheckIptableCmds,
-				[]string{"-C", v, "-m", "set", "--match-set", "crowdsec6-blacklists", "src", "--log-prefix", config.DenyLogPrefix, "-j", "LOG"})
+				ipv6Ctx.StartupCmds = append(ipv6Ctx.StartupCmds,
+					[]string{"-I", v, "-m", "set", "--match-set", "crowdsec6-blacklists", "src", "-j", "LOG", "--log-prefix", config.DenyLogPrefix})
+				ipv6Ctx.ShutdownCmds = append(ipv6Ctx.ShutdownCmds,
+					[]string{"-D", v, "-m", "set", "--match-set", "crowdsec6-blacklists", "src", "-j", "LOG", "--log-prefix", config.DenyLogPrefix})
+				ipv6Ctx.CheckIptableCmds = append(ipv6Ctx.CheckIptableCmds,
+					[]string{"-C", v, "-m", "set", "--match-set", "crowdsec6-blacklists", "src", "-j", "LOG", "--log-prefix", config.DenyLogPrefix})
 			}
 			ipv6Ctx.StartupCmds = append(ipv6Ctx.StartupCmds,
 				[]string{"-I", v, "-m", "set", "--match-set", "crowdsec6-blacklists", "src", "-j", target})

--- a/iptables.go
+++ b/iptables.go
@@ -58,6 +58,12 @@ func newIPTables(config *bouncerConfig) (interface{}, error) {
 			return nil, fmt.Errorf("unable to find iptables")
 		}
 		for _, v := range config.IptablesChains {
+			ipv4Ctx.StartupCmds = append(ipv4Ctx.StartupCmds,
+				[]string{"-I", v, "-m", "set", "--match-set", "crowdsec-blacklists", "src", "-j", target})
+			ipv4Ctx.ShutdownCmds = append(ipv4Ctx.ShutdownCmds,
+				[]string{"-D", v, "-m", "set", "--match-set", "crowdsec-blacklists", "src", "-j", target})
+			ipv4Ctx.CheckIptableCmds = append(ipv4Ctx.CheckIptableCmds,
+				[]string{"-C", v, "-m", "set", "--match-set", "crowdsec-blacklists", "src", "-j", target})
 			if config.DenyLog {
 				ipv4Ctx.StartupCmds = append(ipv4Ctx.StartupCmds,
 					[]string{"-I", v, "-m", "set", "--match-set", "crowdsec-blacklists", "src", "-j", "LOG", "--log-prefix", config.DenyLogPrefix})
@@ -66,12 +72,6 @@ func newIPTables(config *bouncerConfig) (interface{}, error) {
 				ipv4Ctx.CheckIptableCmds = append(ipv4Ctx.CheckIptableCmds,
 					[]string{"-C", v, "-m", "set", "--match-set", "crowdsec-blacklists", "src", "-j", "LOG", "--log-prefix", config.DenyLogPrefix})
 			}
-			ipv4Ctx.StartupCmds = append(ipv4Ctx.StartupCmds,
-				[]string{"-I", v, "-m", "set", "--match-set", "crowdsec-blacklists", "src", "-j", target})
-			ipv4Ctx.ShutdownCmds = append(ipv4Ctx.ShutdownCmds,
-				[]string{"-D", v, "-m", "set", "--match-set", "crowdsec-blacklists", "src", "-j", target})
-			ipv4Ctx.CheckIptableCmds = append(ipv4Ctx.CheckIptableCmds,
-				[]string{"-C", v, "-m", "set", "--match-set", "crowdsec-blacklists", "src", "-j", target})
 		}
 	}
 	ret.v4 = ipv4Ctx
@@ -87,6 +87,12 @@ func newIPTables(config *bouncerConfig) (interface{}, error) {
 			return nil, fmt.Errorf("unable to find ip6tables")
 		}
 		for _, v := range config.IptablesChains {
+			ipv6Ctx.StartupCmds = append(ipv6Ctx.StartupCmds,
+				[]string{"-I", v, "-m", "set", "--match-set", "crowdsec6-blacklists", "src", "-j", target})
+			ipv6Ctx.ShutdownCmds = append(ipv6Ctx.ShutdownCmds,
+				[]string{"-D", v, "-m", "set", "--match-set", "crowdsec6-blacklists", "src", "-j", target})
+			ipv6Ctx.CheckIptableCmds = append(ipv6Ctx.CheckIptableCmds,
+				[]string{"-C", v, "-m", "set", "--match-set", "crowdsec6-blacklists", "src", "-j", target})
 			if config.DenyLog {
 				ipv6Ctx.StartupCmds = append(ipv6Ctx.StartupCmds,
 					[]string{"-I", v, "-m", "set", "--match-set", "crowdsec6-blacklists", "src", "-j", "LOG", "--log-prefix", config.DenyLogPrefix})
@@ -95,12 +101,6 @@ func newIPTables(config *bouncerConfig) (interface{}, error) {
 				ipv6Ctx.CheckIptableCmds = append(ipv6Ctx.CheckIptableCmds,
 					[]string{"-C", v, "-m", "set", "--match-set", "crowdsec6-blacklists", "src", "-j", "LOG", "--log-prefix", config.DenyLogPrefix})
 			}
-			ipv6Ctx.StartupCmds = append(ipv6Ctx.StartupCmds,
-				[]string{"-I", v, "-m", "set", "--match-set", "crowdsec6-blacklists", "src", "-j", target})
-			ipv6Ctx.ShutdownCmds = append(ipv6Ctx.ShutdownCmds,
-				[]string{"-D", v, "-m", "set", "--match-set", "crowdsec6-blacklists", "src", "-j", target})
-			ipv6Ctx.CheckIptableCmds = append(ipv6Ctx.CheckIptableCmds,
-				[]string{"-C", v, "-m", "set", "--match-set", "crowdsec6-blacklists", "src", "-j", target})
 		}
 	}
 	ret.v6 = ipv6Ctx

--- a/iptables.go
+++ b/iptables.go
@@ -60,11 +60,11 @@ func newIPTables(config *bouncerConfig) (interface{}, error) {
 		for _, v := range config.IptablesChains {
 			if config.DenyLog {
 				ipv4Ctx.StartupCmds = append(ipv4Ctx.StartupCmds,
-				[]string{"-I", v, "-m", "set", "--match-set", "crowdsec-blacklists", "src", "--log-prefix", config.DenyLogPrefix, "-j", "LOG"})
+					[]string{"-I", v, "-m", "set", "--match-set", "crowdsec-blacklists", "src", "-j", "LOG", "--log-prefix", config.DenyLogPrefix})
 				ipv4Ctx.ShutdownCmds = append(ipv4Ctx.ShutdownCmds,
-				[]string{"-D", v, "-m", "set", "--match-set", "crowdsec-blacklists", "src", "--log-prefix", config.DenyLogPrefix, "-j", "LOG"})
+					[]string{"-D", v, "-m", "set", "--match-set", "crowdsec-blacklists", "src", "-j", "LOG", "--log-prefix", config.DenyLogPrefix})
 				ipv4Ctx.CheckIptableCmds = append(ipv4Ctx.CheckIptableCmds,
-				[]string{"-C", v, "-m", "set", "--match-set", "crowdsec-blacklists", "src", "--log-prefix", config.DenyLogPrefix, "-j", "LOG"})
+					[]string{"-C", v, "-m", "set", "--match-set", "crowdsec-blacklists", "src", "-j", "LOG", "--log-prefix", config.DenyLogPrefix})
 			}
 			ipv4Ctx.StartupCmds = append(ipv4Ctx.StartupCmds,
 				[]string{"-I", v, "-m", "set", "--match-set", "crowdsec-blacklists", "src", "-j", target})


### PR DESCRIPTION
- Fixes #69 
- We were also inserting the ipv6 iptables command in the ipv4 iptables commands lists, which crashes the bouncer when it tries to set up everything.
- The rules were inserted in the wrong order. As we are using `-I` (which add the rule in the 1st position in the chain in our case), we must first insert the DROP rule then the LOG rule as we want it before.