### PR TITLE
Configure the blacklists name

### DIFF
--- a/config.go
+++ b/config.go
@@ -25,6 +25,8 @@ type bouncerConfig struct {
 	DenyAction      string    `yaml:"deny_action"`
 	DenyLog         bool      `yaml:"deny_log"`
 	DenyLogPrefix   string    `yaml:"deny_log_prefix"`
+	BlacklistsIpv4	string    `yaml:"blacklists_ipv4"`
+	BlacklistsIpv6	string    `yaml:"blacklists_ipv6"`
 	//specific to iptables, following https://github.com/crowdsecurity/cs-firewall-bouncer/issues/19
 	IptablesChains []string `yaml:"iptables_chains"`
 }
@@ -56,6 +58,15 @@ func NewConfig(configPath string) (*bouncerConfig, error) {
 	if config.DenyLog && config.DenyLogPrefix == "" {
 		config.DenyLogPrefix = "crowdsec drop: "
 	}
+
+	if config.BlacklistsIpv4 == "" {
+		config.BlacklistsIpv4 = "crowdsec-blacklists"
+	}
+
+	if config.BlacklistsIpv6 == "" {
+		config.BlacklistsIpv6 = "crowdsec6-blacklists"
+	}
+
 	/*Configure logging*/
 	if err = types.SetDefaultLoggerConfig(config.LogMode, config.LogDir, config.LogLevel); err != nil {
 		log.Fatal(err.Error())

--- a/config/crowdsec-firewall-bouncer.yaml
+++ b/config/crowdsec-firewall-bouncer.yaml
@@ -12,6 +12,9 @@ deny_action: DROP
 deny_log: false
 #to change log prefix
 #deny_log_prefix: "crowdsec: "
+#to change the blacklists name
+#blacklists_ipv4: crowdsec-blacklists
+#blacklists_ipv6: crowdsec6-blacklists
 #if present, insert rule in those chains
 iptables_chains:
   - INPUT

--- a/iptables.go
+++ b/iptables.go
@@ -24,7 +24,7 @@ func newIPTables(config *bouncerConfig) (interface{}, error) {
 	ipv4Ctx := &ipTablesContext{
 		Name:             "ipset",
 		version:          "v4",
-		SetName:          "crowdsec-blacklists",
+		SetName:          config.BlacklistsIpv4,
 		StartupCmds:      [][]string{},
 		ShutdownCmds:     [][]string{},
 		CheckIptableCmds: [][]string{},
@@ -32,7 +32,7 @@ func newIPTables(config *bouncerConfig) (interface{}, error) {
 	ipv6Ctx := &ipTablesContext{
 		Name:             "ipset",
 		version:          "v6",
-		SetName:          "crowdsec6-blacklists",
+		SetName:          config.BlacklistsIpv6,
 		StartupCmds:      [][]string{},
 		ShutdownCmds:     [][]string{},
 		CheckIptableCmds: [][]string{},
@@ -59,18 +59,18 @@ func newIPTables(config *bouncerConfig) (interface{}, error) {
 		}
 		for _, v := range config.IptablesChains {
 			ipv4Ctx.StartupCmds = append(ipv4Ctx.StartupCmds,
-				[]string{"-I", v, "-m", "set", "--match-set", "crowdsec-blacklists", "src", "-j", target})
+				[]string{"-I", v, "-m", "set", "--match-set", ipv4Ctx.SetName, "src", "-j", target})
 			ipv4Ctx.ShutdownCmds = append(ipv4Ctx.ShutdownCmds,
-				[]string{"-D", v, "-m", "set", "--match-set", "crowdsec-blacklists", "src", "-j", target})
+				[]string{"-D", v, "-m", "set", "--match-set", ipv4Ctx.SetName, "src", "-j", target})
 			ipv4Ctx.CheckIptableCmds = append(ipv4Ctx.CheckIptableCmds,
-				[]string{"-C", v, "-m", "set", "--match-set", "crowdsec-blacklists", "src", "-j", target})
+				[]string{"-C", v, "-m", "set", "--match-set", ipv4Ctx.SetName, "src", "-j", target})
 			if config.DenyLog {
 				ipv4Ctx.StartupCmds = append(ipv4Ctx.StartupCmds,
-					[]string{"-I", v, "-m", "set", "--match-set", "crowdsec-blacklists", "src", "-j", "LOG", "--log-prefix", config.DenyLogPrefix})
+					[]string{"-I", v, "-m", "set", "--match-set", ipv4Ctx.SetName, "src", "-j", "LOG", "--log-prefix", config.DenyLogPrefix})
 				ipv4Ctx.ShutdownCmds = append(ipv4Ctx.ShutdownCmds,
-					[]string{"-D", v, "-m", "set", "--match-set", "crowdsec-blacklists", "src", "-j", "LOG", "--log-prefix", config.DenyLogPrefix})
+					[]string{"-D", v, "-m", "set", "--match-set", ipv4Ctx.SetName, "src", "-j", "LOG", "--log-prefix", config.DenyLogPrefix})
 				ipv4Ctx.CheckIptableCmds = append(ipv4Ctx.CheckIptableCmds,
-					[]string{"-C", v, "-m", "set", "--match-set", "crowdsec-blacklists", "src", "-j", "LOG", "--log-prefix", config.DenyLogPrefix})
+					[]string{"-C", v, "-m", "set", "--match-set", ipv4Ctx.SetName, "src", "-j", "LOG", "--log-prefix", config.DenyLogPrefix})
 			}
 		}
 	}
@@ -88,18 +88,18 @@ func newIPTables(config *bouncerConfig) (interface{}, error) {
 		}
 		for _, v := range config.IptablesChains {
 			ipv6Ctx.StartupCmds = append(ipv6Ctx.StartupCmds,
-				[]string{"-I", v, "-m", "set", "--match-set", "crowdsec6-blacklists", "src", "-j", target})
+				[]string{"-I", v, "-m", "set", "--match-set", ipv6Ctx.SetName, "src", "-j", target})
 			ipv6Ctx.ShutdownCmds = append(ipv6Ctx.ShutdownCmds,
-				[]string{"-D", v, "-m", "set", "--match-set", "crowdsec6-blacklists", "src", "-j", target})
+				[]string{"-D", v, "-m", "set", "--match-set", ipv6Ctx.SetName, "src", "-j", target})
 			ipv6Ctx.CheckIptableCmds = append(ipv6Ctx.CheckIptableCmds,
-				[]string{"-C", v, "-m", "set", "--match-set", "crowdsec6-blacklists", "src", "-j", target})
+				[]string{"-C", v, "-m", "set", "--match-set", ipv6Ctx.SetName, "src", "-j", target})
 			if config.DenyLog {
 				ipv6Ctx.StartupCmds = append(ipv6Ctx.StartupCmds,
-					[]string{"-I", v, "-m", "set", "--match-set", "crowdsec6-blacklists", "src", "-j", "LOG", "--log-prefix", config.DenyLogPrefix})
+					[]string{"-I", v, "-m", "set", "--match-set", ipv6Ctx.SetName, "src", "-j", "LOG", "--log-prefix", config.DenyLogPrefix})
 				ipv6Ctx.ShutdownCmds = append(ipv6Ctx.ShutdownCmds,
-					[]string{"-D", v, "-m", "set", "--match-set", "crowdsec6-blacklists", "src", "-j", "LOG", "--log-prefix", config.DenyLogPrefix})
+					[]string{"-D", v, "-m", "set", "--match-set", ipv6Ctx.SetName, "src", "-j", "LOG", "--log-prefix", config.DenyLogPrefix})
 				ipv6Ctx.CheckIptableCmds = append(ipv6Ctx.CheckIptableCmds,
-					[]string{"-C", v, "-m", "set", "--match-set", "crowdsec6-blacklists", "src", "-j", "LOG", "--log-prefix", config.DenyLogPrefix})
+					[]string{"-C", v, "-m", "set", "--match-set", ipv6Ctx.SetName, "src", "-j", "LOG", "--log-prefix", config.DenyLogPrefix})
 			}
 		}
 	}

--- a/iptables_context.go
+++ b/iptables_context.go
@@ -108,10 +108,8 @@ func (ctx *ipTablesContext) shutDown() error {
 		cmd = exec.Command(ctx.iptablesBin, startCmd...)
 		log.Infof("iptables clean-up : %s", cmd.String())
 		if out, err := cmd.CombinedOutput(); err != nil {
-			if strings.Contains(string(out), "Set crowdsec-blacklists doesn't exist.") {
-				log.Infof("ipset 'crowdsec-blacklists' doesn't exist, skip")
-			} else if strings.Contains(string(out), "Set crowdsec6-blacklists doesn't exist.") {
-				log.Infof("ipset 'crowdsec6-blacklists' doesn't exist, skip")
+			if strings.Contains(string(out), "Set " + ctx.SetName + " doesn't exist.") {
+				log.Infof("ipset '%s' doesn't exist, skip", ctx.SetName)
 			} else {
 				log.Errorf("error while removing set entry in iptables : %v --> %s", err, string(out))
 			}
@@ -129,7 +127,7 @@ func (ctx *ipTablesContext) shutDown() error {
 	log.Infof("ipset clean-up : %s", cmd.String())
 	if out, err := cmd.CombinedOutput(); err != nil {
 		if strings.Contains(string(out), "The set with the given name does not exist") {
-			log.Infof("ipset 'crowdsec-blacklists' doesn't exist, skip")
+			log.Infof("ipset '%s' doesn't exist, skip", ctx.SetName)
 		} else {
 			log.Errorf("set %s error : %v - %s", ipsetCmd, err, string(out))
 		}

--- a/nftables.go
+++ b/nftables.go
@@ -26,6 +26,8 @@ type nft struct {
 	DenyAction string
 	DenyLog bool
 	DenyLogPrefix string
+	BlacklistsIpv4 string
+	BlacklistsIpv6 string
 }
 
 func newNFTables(config *bouncerConfig) (interface{}, error) {
@@ -38,6 +40,8 @@ func newNFTables(config *bouncerConfig) (interface{}, error) {
 	ret.DenyAction = config.DenyAction
 	ret.DenyLog = config.DenyLog
 	ret.DenyLogPrefix = config.DenyLogPrefix
+	ret.BlacklistsIpv4 = config.BlacklistsIpv4
+	ret.BlacklistsIpv6 = config.BlacklistsIpv6
 	return ret, nil
 }
 
@@ -50,14 +54,14 @@ func (n *nft) Init() error {
 	n.table = n.conn.AddTable(table)
 
 	chain := n.conn.AddChain(&nftables.Chain{
-		Name:     "crowdsec_chain",
+		Name:     "crowdsec-chain",
 		Table:    n.table,
 		Type:     nftables.ChainTypeFilter,
 		Hooknum:  nftables.ChainHookInput,
 		Priority: nftables.ChainPriorityFilter,
 	})
 	set := &nftables.Set{
-		Name:    "crowdsec_blocklist",
+		Name:    n.BlacklistsIpv4,
 		Table:   n.table,
 		KeyType: nftables.TypeIPAddr,
 	}
@@ -118,14 +122,14 @@ func (n *nft) Init() error {
 		n.table6 = n.conn6.AddTable(table)
 
 		chain := n.conn6.AddChain(&nftables.Chain{
-			Name:     "crowdsec6_chain",
+			Name:     "crowdsec6-chain",
 			Table:    n.table6,
 			Type:     nftables.ChainTypeFilter,
 			Hooknum:  nftables.ChainHookInput,
 			Priority: nftables.ChainPriorityFilter,
 		})
 		set := &nftables.Set{
-			Name:    "crowdsec6_blocklist",
+			Name:    n.BlacklistsIpv6,
 			Table:   n.table6,
 			KeyType: nftables.TypeIP6Addr,
 		}

--- a/pf.go
+++ b/pf.go
@@ -30,9 +30,6 @@ type pf struct {
 const (
 	backendName = "pf"
 
-	pfinetTable  = "crowdsec-blacklists"
-	pfinet6Table = "crowdsec6-blacklists"
-
 	pfctlCmd = "/sbin/pfctl"
 	pfDevice = "/dev/pf"
 
@@ -44,13 +41,13 @@ func newPF(config *bouncerConfig) (interface{}, error) {
 	ret := &pf{}
 
 	inetCtx := &pfContext{
-		table:   pfinetTable,
+		table:   config.BlacklistsIpv4,
 		proto:   "inet",
 		version: "ipv4",
 	}
 
 	inet6Ctx := &pfContext{
-		table:   pfinet6Table,
+		table:   config.BlacklistsIpv6,
 		proto:   "inet6",
 		version: "ipv6",
 	}


### PR DESCRIPTION
Hello,

This PR is in order to be able to choose the name of the blacklists created  in iptables, nftables and pf through the configuration file.

This option is especially useful to install bouncer on pfSense where the default name of the blacklist isn't compatible.

Don't hesitate if you have need more details.