### PR TITLE
Nftables: configurable table/chain/blacklist names & hierarchical YAML config. fixes #74

### DIFF
--- a/config.go
+++ b/config.go
@@ -11,6 +11,14 @@ import (
 	"gopkg.in/yaml.v2"
 )
 
+type nftablesFamilyConfig struct {
+	Enabled   bool   `yaml:"enabled"`
+	SetOnly   bool   `yaml:"set-only"`
+	Table     string `yaml:"table"`
+	Chain     string `yaml:"chain"`
+	Blacklist string `yaml:"blacklist"`
+}
+
 type bouncerConfig struct {
 	Mode            string    `yaml:"mode"` //ipset,iptables,tc
 	PidDir          string    `yaml:"pid_dir"`
@@ -27,9 +35,20 @@ type bouncerConfig struct {
 	DenyLogPrefix   string    `yaml:"deny_log_prefix"`
 	BlacklistsIpv4  string    `yaml:"blacklists_ipv4"`
 	BlacklistsIpv6  string    `yaml:"blacklists_ipv6"`
+
 	//specific to iptables, following https://github.com/crowdsecurity/cs-firewall-bouncer/issues/19
 	IptablesChains          []string `yaml:"iptables_chains"`
 	supportedDecisionsTypes []string `yaml:"supported_decisions_type"`
+	// specific to nftables, following https://github.com/crowdsecurity/cs-firewall-bouncer/issues/74
+	/*	NftablesTable4         string `yaml:"nftables_table4"`
+		NftablesChain4         string `yaml:"nftables_chain4"`
+		NftablesTable6         string `yaml:"nftables_table6"`
+		NftablesChain6         string `yaml:"nftables_chain6"`
+	*/
+	Nftables struct {
+		Ipv4 nftablesFamilyConfig `yaml:"ipv4"`
+		Ipv6 nftablesFamilyConfig `yaml:"ipv6"`
+	} `yaml:"nftables"`
 }
 
 func NewConfig(configPath string) (*bouncerConfig, error) {
@@ -63,13 +82,49 @@ func NewConfig(configPath string) (*bouncerConfig, error) {
 	if config.DenyLog && config.DenyLogPrefix == "" {
 		config.DenyLogPrefix = "crowdsec drop: "
 	}
-
-	if config.BlacklistsIpv4 == "" {
-		config.BlacklistsIpv4 = "crowdsec-blacklists"
+	// for config file backward compatibility
+	if config.BlacklistsIpv4 != "" {
+		config.Nftables.Ipv4.Blacklist = config.BlacklistsIpv4
 	}
 
-	if config.BlacklistsIpv6 == "" {
-		config.BlacklistsIpv6 = "crowdsec6-blacklists"
+	if config.BlacklistsIpv6 != "" {
+		config.Nftables.Ipv6.Blacklist = config.BlacklistsIpv6
+	}
+
+	// nftables IPv4 specific
+	if config.Nftables.Ipv4.Enabled {
+		if config.Nftables.Ipv4.Table == "" {
+			config.Nftables.Ipv4.Table = "crowdsec"
+		}
+
+		if config.Nftables.Ipv4.Chain == "" {
+			config.Nftables.Ipv4.Chain = "crowdsec-chain"
+		}
+
+		if config.Nftables.Ipv4.Blacklist == "" {
+			config.Nftables.Ipv4.Blacklist = "crowdsec-blacklist"
+		}
+	}
+	// nftables IPv6 specific
+	// What if config.DisableIPV6 (bool) has not been defined?
+	if config.DisableIPV6 {
+		config.Nftables.Ipv6.Enabled = false
+	}
+	// for config file compability
+	config.DisableIPV6 = !config.Nftables.Ipv6.Enabled
+
+	if config.Nftables.Ipv6.Enabled {
+		if config.Nftables.Ipv6.Table == "" {
+			config.Nftables.Ipv6.Table = "crowdsec6"
+		}
+
+		if config.Nftables.Ipv6.Chain == "" {
+			config.Nftables.Ipv6.Chain = "crowdsec6-chain"
+		}
+
+		if config.Nftables.Ipv6.Blacklist == "" {
+			config.Nftables.Ipv6.Blacklist = "crowdsec6-blacklist"
+		}
 	}
 
 	/*Configure logging*/
@@ -107,6 +162,10 @@ func validateConfig(config bouncerConfig) error {
 
 	if config.LogMode != "stdout" && config.LogMode != "file" {
 		return fmt.Errorf("log mode '%s' unknown, expecting 'file' or 'stdout'", config.LogMode)
+	}
+
+	if config.Nftables.Ipv4.Enabled == false && config.Nftables.Ipv6.Enabled == false {
+		return fmt.Errorf("Both IPv4 and IPv6 disabled, doing nothing")
 	}
 	return nil
 }

--- a/config/crowdsec-firewall-bouncer.yaml
+++ b/config/crowdsec-firewall-bouncer.yaml
@@ -22,3 +22,18 @@ iptables_chains:
   - INPUT
 #  - FORWARD
 #  - DOCKER-USER
+
+## nftables
+nftables:
+  ipv4:
+    enabled: true
+    blacklist: crowdsec-blacklists
+    set-only: false
+    table: crowdsec
+    chain: crowdsec-chain
+  ipv6:
+    enabled: false
+    blacklist: crowdsec6-blacklists
+    set-only: false
+    table: crowdsec6
+    chain: crowdsec6-chain

--- a/config/crowdsec-firewall-bouncer.yaml
+++ b/config/crowdsec-firewall-bouncer.yaml
@@ -27,13 +27,13 @@ iptables_chains:
 nftables:
   ipv4:
     enabled: true
-    blacklist: crowdsec-blacklists
+    blacklist: crowdsec-blacklist
     set-only: false
     table: crowdsec
     chain: crowdsec-chain
   ipv6:
     enabled: false
-    blacklist: crowdsec6-blacklists
+    blacklist: crowdsec6-blacklist
     set-only: false
     table: crowdsec6
     chain: crowdsec6-chain

--- a/config/crowdsec-firewall-bouncer.yaml
+++ b/config/crowdsec-firewall-bouncer.yaml
@@ -32,7 +32,7 @@ nftables:
     table: crowdsec
     chain: crowdsec-chain
   ipv6:
-    enabled: false
+    enabled: true
     blacklist: crowdsec6-blacklist
     set-only: false
     table: crowdsec6


### PR DESCRIPTION
*This is my very first Go project ever (just learned `golang` syntax yesterday) and my very first GH upstream contribution. I beg your forgiveness.*

This PR: 

## 1. Adds support for configurable nftables table/chain/blacklist (set) names for both ipv4 and ipv6.

* fixes #74 
* Configuration can be done separately for `ipv4` and `ipv6`
 
## 2. Adds support for `set-only` mode for easier integration into existing `nftables`setups

* When `set-only: true`, `crowdsec-firewall-bouncer` only updates its blackist(s)  (i.e. nftables sets) instead of creating its own table/chain/rules. 
* Default is the legacy mode: `set-only: false`
* This enables easier integration of `crowdsec` into existing `nftables` setups. 
* It is left for the admin to integrate these sets/blacklists into their existing firewall setup. 
* The sets (ipv4/v6) are  automatically created if those do not exist, but those are never deleted, only flushed at exit. 

## 3. Changes `nftables` yaml configuration hierarchical

* Hierarchical config file for `nftables`: e.g. `nftables.ipv4.table: crowdsec`
* Enable/disable `ipv4` / `ipv6` separately: `nftables.ipv4.enabled: true`. 
* Backward support for the old configs: `disable_ipv6`, `blacklists_ipv4`, `blacklists_ipv6`
* Default table names are the same as earlier: `crowdsec`/`crowdsec6`
* Default chain names use hyphen `-` to follow common `yaml` practices: `crowdsec_chain` => `crowdsec-chain`, `crowdsec6_chain` => `crowdsec6-chain`
* Default `blacklist` names are singular vs plural: `crowdsec-blacklists` => `crowdsec-blacklist`, `crowdsec6-blacklists` => `crowdsec6-blacklist`

```
## nftables
nftables:
  ipv4:
    enabled: true
    blacklist: crowdsec-blacklist
    set-only: false
    table: crowdsec
    chain: crowdsec-chain
  ipv6:
    enabled: false
    blacklist: crowdsec6-blacklist
    set-only: false
    table: crowdsec6
    chain: crowdsec6-chain
```