### PR TITLE
Nftables batch processing performance improvement. fixes #114

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,14 @@
+
 # Binaries for programs and plugins
+cs-firewall-bouncer
 *.exe
 *.exe~
 *.dll
 *.so
 *.dylib
+
+# git
+.gitignore
 
 # Test binary, built with `go test -c`
 *.test
@@ -13,3 +18,5 @@
 
 # Dependency directories (remove the comment below to include it)
 # vendor/
+*.swp
+

--- a/backend.go
+++ b/backend.go
@@ -21,8 +21,8 @@ type backend interface {
 
 type backendCTX struct {
 	firewall          backend
-	bufferedDecisions int
 	buffered          bool
+	bufferedDecisions int
 	bufferedDeletions map[string]*models.Decision
 	bufferedAdditions map[string]*models.Decision
 }
@@ -123,7 +123,7 @@ func (b *backendCTX) Commit() error {
 			nounAdded = "decision"
 		}
 
-		log.Debugf("committing %d unique deleted %s and %d unique added %s", len(b.bufferedDeletions), nounDeleted, len(b.bufferedAdditions), nounAdded)
+		log.Debugf("committing %d unique delete %s and %d unique add %s", len(b.bufferedDeletions), nounDeleted, len(b.bufferedAdditions), nounAdded)
 		b.bufferedDeletions = make(map[string]*models.Decision)
 		b.bufferedAdditions = make(map[string]*models.Decision)
 

--- a/config.go
+++ b/config.go
@@ -33,8 +33,8 @@ type bouncerConfig struct {
 	DenyAction      string    `yaml:"deny_action"`
 	DenyLog         bool      `yaml:"deny_log"`
 	DenyLogPrefix   string    `yaml:"deny_log_prefix"`
-	BlacklistsIpv4  string    `yaml:"blacklists_ipv4"`
-	BlacklistsIpv6  string    `yaml:"blacklists_ipv6"`
+	BlacklistsIpv4  string    `yaml:"crowdsec-blacklist"`
+	BlacklistsIpv6  string    `yaml:"crowdsec6-blacklist"`
 
 	//specific to iptables, following https://github.com/crowdsecurity/cs-firewall-bouncer/issues/19
 	IptablesChains          []string `yaml:"iptables_chains"`

--- a/config.go
+++ b/config.go
@@ -11,6 +11,14 @@ import (
 	"gopkg.in/yaml.v2"
 )
 
+type nftablesFamilyConfig struct {
+	Enabled   bool   `yaml:"enabled"`
+	SetOnly   bool   `yaml:"set-only"`
+	Table     string `yaml:"table"`
+	Chain     string `yaml:"chain"`
+	Blacklist string `yaml:"blacklist"`
+}
+
 type bouncerConfig struct {
 	Mode            string    `yaml:"mode"` //ipset,iptables,tc
 	PidDir          string    `yaml:"pid_dir"`
@@ -27,9 +35,20 @@ type bouncerConfig struct {
 	DenyLogPrefix   string    `yaml:"deny_log_prefix"`
 	BlacklistsIpv4  string    `yaml:"blacklists_ipv4"`
 	BlacklistsIpv6  string    `yaml:"blacklists_ipv6"`
+
 	//specific to iptables, following https://github.com/crowdsecurity/cs-firewall-bouncer/issues/19
 	IptablesChains          []string `yaml:"iptables_chains"`
 	supportedDecisionsTypes []string `yaml:"supported_decisions_type"`
+	// specific to nftables, following https://github.com/crowdsecurity/cs-firewall-bouncer/issues/74
+	/*	NftablesTable4         string `yaml:"nftables_table4"`
+		NftablesChain4         string `yaml:"nftables_chain4"`
+		NftablesTable6         string `yaml:"nftables_table6"`
+		NftablesChain6         string `yaml:"nftables_chain6"`
+	*/
+	Nftables struct {
+		Ipv4 nftablesFamilyConfig `yaml:"ipv4"`
+		Ipv6 nftablesFamilyConfig `yaml:"ipv6"`
+	} `yaml:"nftables"`
 }
 
 func NewConfig(configPath string) (*bouncerConfig, error) {
@@ -63,13 +82,49 @@ func NewConfig(configPath string) (*bouncerConfig, error) {
 	if config.DenyLog && config.DenyLogPrefix == "" {
 		config.DenyLogPrefix = "crowdsec drop: "
 	}
-
-	if config.BlacklistsIpv4 == "" {
-		config.BlacklistsIpv4 = "crowdsec-blacklists"
+	// for config file backward compatibility
+	if config.BlacklistsIpv4 != "" {
+		config.Nftables.Ipv4.Blacklist = config.BlacklistsIpv4
 	}
 
-	if config.BlacklistsIpv6 == "" {
-		config.BlacklistsIpv6 = "crowdsec6-blacklists"
+	if config.BlacklistsIpv6 != "" {
+		config.Nftables.Ipv6.Blacklist = config.BlacklistsIpv6
+	}
+
+	// nftables IPv4 specific
+	if config.Nftables.Ipv4.Enabled {
+		if config.Nftables.Ipv4.Table == "" {
+			config.Nftables.Ipv4.Table = "crowdsec"
+		}
+
+		if config.Nftables.Ipv4.Chain == "" {
+			config.Nftables.Ipv4.Chain = "crowdsec-chain"
+		}
+
+		if config.Nftables.Ipv4.Blacklist == "" {
+			config.Nftables.Ipv4.Blacklist = "crowdsec-blacklist"
+		}
+	}
+	// nftables IPv6 specific
+	// What if config.DisableIPV6 (bool) has not been defined?
+	if config.DisableIPV6 {
+		config.Nftables.Ipv6.Enabled = false
+	}
+	// for config file compability
+	config.DisableIPV6 = !config.Nftables.Ipv6.Enabled
+
+	if config.Nftables.Ipv6.Enabled {
+		if config.Nftables.Ipv6.Table == "" {
+			config.Nftables.Ipv6.Table = "crowdsec6"
+		}
+
+		if config.Nftables.Ipv6.Chain == "" {
+			config.Nftables.Ipv6.Chain = "crowdsec6-chain"
+		}
+
+		if config.Nftables.Ipv6.Blacklist == "" {
+			config.Nftables.Ipv6.Blacklist = "crowdsec6-blacklist"
+		}
 	}
 
 	/*Configure logging*/
@@ -107,6 +162,10 @@ func validateConfig(config bouncerConfig) error {
 
 	if config.LogMode != "stdout" && config.LogMode != "file" {
 		return fmt.Errorf("log mode '%s' unknown, expecting 'file' or 'stdout'", config.LogMode)
+	}
+
+	if config.Nftables.Ipv4.Enabled == false && config.Nftables.Ipv6.Enabled == false {
+		return fmt.Errorf("Both IPv4 and IPv6 disabled, doing nothing")
 	}
 	return nil
 }

--- a/config/crowdsec-firewall-bouncer.yaml
+++ b/config/crowdsec-firewall-bouncer.yaml
@@ -22,3 +22,18 @@ iptables_chains:
   - INPUT
 #  - FORWARD
 #  - DOCKER-USER
+
+## nftables
+nftables:
+  ipv4:
+    enabled: true
+    blacklist: crowdsec-blacklists
+    set-only: false
+    table: crowdsec
+    chain: crowdsec-chain
+  ipv6:
+    enabled: false
+    blacklist: crowdsec6-blacklists
+    set-only: false
+    table: crowdsec6
+    chain: crowdsec6-chain

--- a/config/crowdsec-firewall-bouncer.yaml
+++ b/config/crowdsec-firewall-bouncer.yaml
@@ -32,7 +32,7 @@ nftables:
     table: crowdsec
     chain: crowdsec-chain
   ipv6:
-    enabled: false
+    enabled: true
     blacklist: crowdsec6-blacklists
     set-only: false
     table: crowdsec6

--- a/config/crowdsec-firewall-bouncer.yaml
+++ b/config/crowdsec-firewall-bouncer.yaml
@@ -33,7 +33,7 @@ nftables:
     chain: crowdsec-chain
   ipv6:
     enabled: true
-    blacklist: crowdsec6-blacklists
+    blacklist: crowdsec6-blacklist
     set-only: false
     table: crowdsec6
     chain: crowdsec6-chain

--- a/debian/control
+++ b/debian/control
@@ -8,10 +8,12 @@ Architecture: any
 Description: Firewall bouncer for Crowdsec (iptables+ipset)
 Depends: iptables, ipset, gettext-base
 Replaces: crowdsec-firewall-bouncer
+Conflicts: crowdsec-firewall-bouncer-nftables
 
 Package: crowdsec-firewall-bouncer-nftables
 Architecture: any
 Description: Firewall bouncer for Crowdsec (nftables)
 Depends: nftables, gettext-base
 Replaces: crowdsec-firewall-bouncer
+Conflicts: crowdsec-firewall-bouncer-iptables
 

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,6 @@ module github.com/crowdsecurity/cs-firewall-bouncer
 go 1.14
 
 require (
-	github.com/ahmetb/dlog v0.0.0-20170105205344-4fb5f8204f26 // indirect
 	github.com/antonmedv/expr v1.9.0 // indirect
 	github.com/coreos/go-systemd v0.0.0-20191104093116-d3cd4ed1dbcf
 	github.com/crowdsecurity/crowdsec v1.2.2

--- a/iptables.go
+++ b/iptables.go
@@ -187,6 +187,10 @@ func (ipt *iptables) ShutDown() error {
 	return nil
 }
 
+func (ipt *iptables) Commit() error {
+	return nil
+}
+
 func (ipt *iptables) Delete(decision *models.Decision) error {
 	done := false
 	if strings.Contains(*decision.Value, ":") {

--- a/main.go
+++ b/main.go
@@ -177,13 +177,13 @@ func main() {
 					nbNewDecisions++
 				}
 
-				nounAdd := "decisions"
+				/* nounAdd := "decisions"
 				if nbNewDecisions == 1 {
 					nounAdd = "decision"
 				}
 				if nbNewDecisions > 0 {
 					log.Infof("%d %s added", nbNewDecisions, nounAdd)
-				}
+				} */
 
 				if nbDeletedDecisions+nbNewDecisions > 0 {
 					noun := "decisions"
@@ -193,7 +193,7 @@ func main() {
 					if err := backend.Commit(); err != nil {
 						log.Errorf("error committing %s: %s", noun, err)
 					}
-					log.Infof("committed %d added %s, %d deleted %s", nbNewDecisions, nounAdd, nbDeletedDecisions, nounDel)
+					// log.Infof("committed %d added %s, %d deleted %s", nbNewDecisions, nounAdd, nbDeletedDecisions, nounDel)
 				}
 			}
 		}

--- a/nftables.go
+++ b/nftables.go
@@ -329,6 +329,9 @@ func (n *nft) Add(decision *models.Decision) error {
 			/* if err := n.conn.Flush(); err != nil {
 				return err
 			} */
+		} else {
+			log.Debugf("not adding '%s' because ipv4 is disabled", *decision.Value)
+			return nil
 		}
 	}
 

--- a/pf.go
+++ b/pf.go
@@ -191,6 +191,10 @@ func (pf *pf) Delete(decision *models.Decision) error {
 	return nil
 }
 
+func (pf *pf) Commit() error {
+	return nil
+}
+
 func (pf *pf) ShutDown() error {
 	log.Infof("flushing 'crowdsec' table(s)")
 


### PR DESCRIPTION
This PR builds on PR #111 (configurable table/chain/set names for `nftables`) and adds `nftables` batch processing to speed up rule processing.  

This PR is similar to #114 , but less-feature-rich and thus simpler from code perspective. It does not compare the current state of the sets, but leaves that to the underlying `nftables` infra to manage. Considering how the rules could be updated every few seconds, this is expected to reduce the processing requirements that can be important for low-powered HW. 

As PR #114, this PR is implemented as extending `backend interface` with new method `Commit() error`. 

Backends' support for buffered mode is tracked by `backendCTX struct` variable `buffered bool` and the number of buffered decisions is counted with `backendCTX struct` variable `bufferedDecisions int`. 

```
type backendCTX struct {
	firewall          backend
	bufferedDecisions int
	buffering         bool
}
```

`Flush()` netlink command submitting the decisions in batch to the `netlink` backend has been commented out from `nftables` `Add()` and `Delete()` methods. A dummy `Commit()` methods have been added into `iptables.go` and `pf.go`.

```
			/* if err := n.conn6.Flush(); err != nil {
				return err
			} */
...
			/* if err := n.conn6.Flush(); err != nil {
				return err
			} */
```
