### PR TITLE
pf: default to no anchor

### DIFF
--- a/config.go
+++ b/config.go
@@ -55,7 +55,7 @@ type bouncerConfig struct {
 		Ipv6 nftablesFamilyConfig `yaml:"ipv6"`
 	} `yaml:"nftables"`
 	PF struct {
-		AnchorName *string `yaml:"anchor_name"`
+		AnchorName string `yaml:"anchor_name"`
 	} `yaml:"pf"`
 }
 
@@ -116,11 +116,6 @@ func newConfig(configPath string) (*bouncerConfig, error) {
 }
 
 func pfConfig(config *bouncerConfig) error {
-	// to avoid using an anchor, it has to be set to an empty string
-	// in the config file
-	if config.PF.AnchorName == nil {
-		config.PF.AnchorName = types.StrPtr("crowdsec")
-	}
 	return nil
 }
 

--- a/config/crowdsec-firewall-bouncer.yaml
+++ b/config/crowdsec-firewall-bouncer.yaml
@@ -42,4 +42,4 @@ nftables:
 # packet filter
 pf:
   # an empty string disables the anchor
-  anchor_name: crowdsec
+  anchor_name: ""

--- a/pf.go
+++ b/pf.go
@@ -42,14 +42,14 @@ func newPF(config *bouncerConfig) (backend, error) {
 	inetCtx := &pfContext{
 		table:   config.BlacklistsIpv4,
 		proto:   "inet",
-		anchor:  *config.PF.AnchorName,
+		anchor:  config.PF.AnchorName,
 		version: "ipv4",
 	}
 
 	inet6Ctx := &pfContext{
 		table:   config.BlacklistsIpv6,
 		proto:   "inet6",
-		anchor:  *config.PF.AnchorName,
+		anchor:  config.PF.AnchorName,
 		version: "ipv6",
 	}
 


### PR DESCRIPTION
We don't use anchors for opnsense anymore. They stay as an option.