### PR TITLE
Set api url to 127.0.0.1 instead of localhost

### DIFF
--- a/config/crowdsec-firewall-bouncer.yaml
+++ b/config/crowdsec-firewall-bouncer.yaml
@@ -9,7 +9,7 @@ log_compression: true
 log_max_size: 100
 log_max_backups: 3
 log_max_age: 30
-api_url: http://localhost:8080/
+api_url: http://127.0.0.1:8080/
 api_key: ${API_KEY}
 insecure_skip_verify: false
 disable_ipv6: false

--- a/debian/crowdsec-firewall-bouncer-iptables.postinst
+++ b/debian/crowdsec-firewall-bouncer-iptables.postinst
@@ -36,7 +36,8 @@ fi
 if command -v "$CSCLI" >/dev/null; then
     PORT=$(cscli config show --key "Config.API.Server.ListenURI"|cut -d ":" -f2)
     if [ ! -z "$PORT" ]; then
-       sed -i "s/localhost:8080/localhost:${PORT}/g" /etc/crowdsec/bouncers/crowdsec-firewall-bouncer.yaml
+       sed -i "s/localhost:8080/127.0.0.1:${PORT}/g" /etc/crowdsec/bouncers/crowdsec-firewall-bouncer.yaml
+       sed -i "s/127.0.0.1:8080/127.0.0.1:${PORT}/g" /etc/crowdsec/bouncers/crowdsec-firewall-bouncer.yaml
     fi
 fi
 

--- a/debian/crowdsec-firewall-bouncer-nftables.postinst
+++ b/debian/crowdsec-firewall-bouncer-nftables.postinst
@@ -35,7 +35,8 @@ fi
 if command -v "$CSCLI" >/dev/null; then
     PORT=$(cscli config show --key "Config.API.Server.ListenURI"|cut -d ":" -f2)
     if [ ! -z "$PORT" ]; then
-       sed -i "s/localhost:8080/localhost:${PORT}/g" /etc/crowdsec/bouncers/crowdsec-firewall-bouncer.yaml
+       sed -i "s/localhost:8080/127.0.0.1:${PORT}/g" /etc/crowdsec/bouncers/crowdsec-firewall-bouncer.yaml
+       sed -i "s/127.0.0.1:8080/127.0.0.1:${PORT}/g" /etc/crowdsec/bouncers/crowdsec-firewall-bouncer.yaml
     fi
 fi
 

--- a/rpm/SPECS/crowdsec-firewall-bouncer.spec
+++ b/rpm/SPECS/crowdsec-firewall-bouncer.spec
@@ -88,7 +88,8 @@ fi
 if command -v "$CSCLI" >/dev/null; then
     PORT=$(cscli config show --key "Config.API.Server.ListenURI"|cut -d ":" -f2)
     if [ ! -z "$PORT" ]; then
-       sed -i "s/localhost:8080/localhost:${PORT}/g" /etc/crowdsec/bouncers/crowdsec-firewall-bouncer.yaml
+       sed -i "s/localhost:8080/127.0.0.1:${PORT}/g" /etc/crowdsec/bouncers/crowdsec-firewall-bouncer.yaml
+       sed -i "s/127.0.0.1:8080/127.0.0.1:${PORT}/g" /etc/crowdsec/bouncers/crowdsec-firewall-bouncer.yaml
     fi
 fi
 
@@ -148,7 +149,8 @@ fi
 if command -v "$CSCLI" >/dev/null; then
     PORT=$(cscli config show --key "Config.API.Server.ListenURI"|cut -d ":" -f2)
     if [ ! -z "$PORT" ]; then     
-       sed -i "s/localhost:8080/localhost:${PORT}/g" /etc/crowdsec/bouncers/crowdsec-firewall-bouncer.yaml
+       sed -i "s/localhost:8080/127.0.0.1:${PORT}/g" /etc/crowdsec/bouncers/crowdsec-firewall-bouncer.yaml
+       sed -i "s/127.0.0.1:8080/127.0.0.1:${PORT}/g" /etc/crowdsec/bouncers/crowdsec-firewall-bouncer.yaml
     fi
 fi
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -117,6 +117,7 @@ install_firewall_bouncer() {
 }
 
 
+
 if ! [ $(id -u) = 0 ]; then
     echo "Please run the install script as root or with sudo"
     exit 1
@@ -128,6 +129,15 @@ echo "Installing firewall-bouncer"
 install_firewall_bouncer
 gen_apikey
 gen_config_file
+
+if command -v "$CSCLI" >/dev/null; then
+    PORT=$(cscli config show --key "Config.API.Server.ListenURI"|cut -d ":" -f2)
+    if [ ! -z "$PORT" ]; then
+       sed -i "s/localhost:8080/127.0.0.1:${PORT}/g" "${CONFIG_DIR}crowdsec-firewall-bouncer.yaml"
+       sed -i "s/127.0.0.1:8080/127.0.0.1:${PORT}/g" "${CONFIG_DIR}crowdsec-firewall-bouncer.yaml"
+    fi
+fi
+
 systemctl enable crowdsec-firewall-bouncer.service
 if [ "$READY" = "yes" ]; then
     systemctl start crowdsec-firewall-bouncer.service

--- a/tests/iptables/crowdsec-firewall-bouncer.yaml
+++ b/tests/iptables/crowdsec-firewall-bouncer.yaml
@@ -5,7 +5,7 @@ daemonize: false
 log_mode: stdout
 log_dir: ./
 log_level: info
-api_url: http://localhost:8081/
+api_url: http://127.0.0.1:8081/
 api_key: 1237adaf7a1724ac68a3288828820a67
 disable_ipv6: false
 deny_action: DROP

--- a/tests/nftables/crowdsec-firewall-bouncer.yaml
+++ b/tests/nftables/crowdsec-firewall-bouncer.yaml
@@ -5,7 +5,7 @@ daemonize: false
 log_mode: stdout
 log_dir: ./
 log_level: info
-api_url: http://localhost:8081/
+api_url: http://127.0.0.1:8081/
 api_key: 1237adaf7a1724ac68a3288828820a67
 disable_ipv6: false
 deny_action: DROP


### PR DESCRIPTION
- Change `localhost` to `127.0.0.1` everywhere for the local API URL in configuration
- Fix install.sh script to support non-default local API port.