### PR TITLE
Multi config

### DIFF
--- a/config.go
+++ b/config.go
@@ -63,7 +63,7 @@ type bouncerConfig struct {
 func newConfig(configPath string) (*bouncerConfig, error) {
 	config := &bouncerConfig{}
 
-	log.Warningf("loading config file: %s", configPath)
+	log.Infof("loading config file: %s", configPath)
 
 	configBuff, err := ioutil.ReadFile(configPath)
 	if err != nil {
@@ -78,7 +78,7 @@ func newConfig(configPath string) (*bouncerConfig, error) {
 	for includedPathIndex := range config.Includes {
 		files, _ := filepath.Glob(config.Includes[includedPathIndex])
 		for s := range files {
-			log.Warningf("loading included config file: %s", files[s])
+			log.Infof("loading included config file: %s", files[s])
 
 			includedConfigBuff, err := ioutil.ReadFile(files[s])
 			if err != nil {

--- a/config/crowdsec-firewall-bouncer.yaml
+++ b/config/crowdsec-firewall-bouncer.yaml
@@ -44,3 +44,5 @@ nftables:
 pf:
   # an empty string disables the anchor
   anchor_name: ""
+includes:
+  - /etc/crowdsec/bouncers/crowdsec-firewall-bouncer.d/*.yaml


### PR DESCRIPTION
The idea is to have the ability to include multiple config files.
Yaml is not really meant for this, so I usually include other files that way.

This should allow to have better compatibility with debian systems.
When you do an ```apt update``` of a package that has "customized" config file, apt is complaining and asking questions, that's why a lot of programs in debian systems allow splitting the configuration in multiple files (some managed by the package itself and some managed by the user).

We can now have the standard `/etc/crowdsec/bouncers/crowdsec-firewall-bouncer.yaml`, and some files in `/etc/crowdsec/bouncers/crowdsec-firewall-bouncer.d/`.
