### PR TITLE
install.sh: fix iptables detection

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -25,9 +25,10 @@ check_pkg_manager(){
 }
 
 check_firewall() {
+    FW_BACKEND=""
+
     iptables="true"
     which iptables > /dev/null
-    FW_BACKEND=""
     if [[ $? != 0 ]]; then 
         echo "iptables is not present"
         iptables="false"


### PR DESCRIPTION
The `install.sh` script was unconditionally setting the `iptables` variable to `true`, because the `FW_BACKEND=""` setting was masking the exit code of `which iptables > /dev/null`.