### PR TITLE
make: accept BUILD_VENDOR_FLAGS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,8 @@
 
 # built binaries
 /crowdsec-firewall-bouncer
+/crowdsec-firewall-bouncer.tgz
+/crowdsec-firewall-bouncer*/
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,7 @@ lint:
 	golangci-lint run
 
 build: goversion clean
-	$(GOBUILD) $(LD_OPTS) -o $(BINARY_NAME)
+	$(GOBUILD) $(LD_OPTS) $(BUILD_VENDOR_FLAGS) -o $(BINARY_NAME)
 
 test:
 	@$(GOTEST) $(LD_OPTS) ./...


### PR DESCRIPTION
this is used to avoid patching the makefile when building for freebsd