### PR TITLE
Revert "Nftables: Add configurable hooks (#231)"

### DIFF
--- a/config.go
+++ b/config.go
@@ -62,8 +62,7 @@ type bouncerConfig struct {
 		Ipv4 nftablesFamilyConfig `yaml:"ipv4"`
 		Ipv6 nftablesFamilyConfig `yaml:"ipv6"`
 	} `yaml:"nftables"`
-	NftablesHooks []string `yaml:"nftables_hooks"`
-	PF            struct {
+	PF struct {
 		AnchorName string `yaml:"anchor_name"`
 		BatchSize  int    `yaml:"batch_size"`
 	} `yaml:"pf"`
@@ -188,10 +187,6 @@ func nftablesConfig(config *bouncerConfig) error {
 
 	if !*config.Nftables.Ipv4.Enabled && !*config.Nftables.Ipv6.Enabled {
 		return fmt.Errorf("both IPv4 and IPv6 disabled, doing nothing")
-	} else {
-		if config.NftablesHooks == nil || len(config.NftablesHooks) == 0 {
-			config.NftablesHooks = []string{"input"}
-		}
 	}
 
 	return nil

--- a/config/crowdsec-firewall-bouncer.yaml
+++ b/config/crowdsec-firewall-bouncer.yaml
@@ -42,10 +42,6 @@ nftables:
     set-only: false
     table: crowdsec6
     chain: crowdsec6-chain
-nftables_hooks:
-  - input
-  - forward
-
 # packet filter
 pf:
   # an empty string disables the anchor

--- a/test/nftables/crowdsec-firewall-bouncer.yaml
+++ b/test/nftables/crowdsec-firewall-bouncer.yaml
@@ -15,10 +15,6 @@ supported_decisions_types:
 iptables_chains:
   - INPUT
 
-nftables_hooks:
-  - input
-  - forward
-
 nftables:
   ipv4:
     enabled: true

--- a/test/nftables/test_nftables.py
+++ b/test/nftables/test_nftables.py
@@ -51,8 +51,7 @@ class TestNFTables(unittest.TestCase):
         rules = {
             node["rule"]["chain"] for node in output["nftables"] if "rule" in node
         }  # maybe stricter check ?
-        assert "crowdsec-chain-forward" in rules
-        assert "crowdsec-chain-input" in rules
+        assert "crowdsec-chain" in rules
 
         # IPV6
         output = json.loads(run_cmd("nft", "-j", "list", "table", "ip6", "crowdsec6"))
@@ -66,8 +65,7 @@ class TestNFTables(unittest.TestCase):
         rules = {
             node["rule"]["chain"] for node in output["nftables"] if "rule" in node
         }  # maybe stricter check ?
-        assert "crowdsec6-chain-input" in rules
-        assert "crowdsec6-chain-forward" in rules
+        assert "crowdsec6-chain" in rules
 
     def test_duplicate_decisions_across_decision_stream(self):
         d1, d2, d3 = generate_n_decisions(3, dup_count=1)


### PR DESCRIPTION
This reverts commit 9aebcfbf0884a5d6ed12f741fad180dd9a7208fb.

Need to investigate. The reverted code creates the following errors upon startup with mode=nftables:

`level=error msg=“can’t collect dropped packets for ipv4 from nft: exit status 1”`