### PR TITLE
Correct backend cleanup and return code

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -227,7 +227,7 @@ func Execute() error {
 	}
 
 	if err := g.Wait(); err != nil {
-		return fmt.Errorf("process terminated with error: %s", err)
+		return fmt.Errorf("process terminated with error: %w", err)
 	}
 
 	return nil

--- a/main.go
+++ b/main.go
@@ -1,7 +1,14 @@
 package main
 
-import "github.com/crowdsecurity/cs-firewall-bouncer/cmd"
+import (
+	log "github.com/sirupsen/logrus"
+
+	"github.com/crowdsecurity/cs-firewall-bouncer/cmd"
+)
 
 func main() {
-	cmd.Execute()
+	err := cmd.Execute()
+	if err != nil {
+		log.Fatal(err)
+	}
 }


### PR DESCRIPTION
The backend cleanup was only called from the signal handler, defer was ignored. Now there's a nice message and proper return codes

time="03-05-2023 12:43:02" level=info msg="6987 decisions added"
time="03-05-2023 12:43:10" level=info msg="Shutting down backend"
time="03-05-2023 12:43:10" level=info msg="removing 'crowdsec' table"
time="03-05-2023 12:43:10" level=info msg="removing 'crowdsec6' table"
time="03-05-2023 12:43:10" level=fatal msg="process terminating with error: received SIGTERM"