### PR TITLE
symlink /usr/sbin/{bouncer} to /usr/bin/

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -1,7 +1,7 @@
 [packages]
 exceptiongroup = "1.1.1"
 pexpect = "4.8.0"
-pytest-cs = {ref = "0.7.15", git = "https://github.com/crowdsecurity/pytest-cs.git"}
+pytest-cs = {ref = "0.7.16", git = "https://github.com/crowdsecurity/pytest-cs.git"}
 pytest-dependency = "0.5.1"
 pytest-dotenv = "0.5.2"
 flask = "2.2.3"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "d035b9d4e82a85395e07fe4b9a892645e72665cb1d28b911e287a2061771aacc"
+            "sha256": "c1f622d66dd61981fcc94900950440e95998b17fcfebf3f98d10d4c16c502632"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -217,11 +217,11 @@
         },
         "docker": {
             "hashes": [
-                "sha256:5ec18b9c49d48ee145a5b5824bb126dc32fc77931e18444783fc07a7724badc0",
-                "sha256:8308b23d3d0982c74f7aa0a3abd774898c0c4fba006e9c3bde4f68354e470fe2"
+                "sha256:134cd828f84543cbf8e594ff81ca90c38288df3c0a559794c12f2e4b634ea19e",
+                "sha256:dcc088adc2ec4e7cfc594e275d8bd2c9738c56c808de97476939ef67db5af8c2"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==6.1.1"
+            "version": "==6.1.2"
         },
         "exceptiongroup": {
             "hashes": [
@@ -395,7 +395,7 @@
         },
         "pytest-cs": {
             "git": "https://github.com/crowdsecurity/pytest-cs.git",
-            "ref": "e146c11a6024f5156e590f25483d822badea6bb3"
+            "ref": "4a3451084215053af8a48ff37507b4f86bf75c10"
         },
         "pytest-datadir": {
             "hashes": [

--- a/debian/rules
+++ b/debian/rules
@@ -21,6 +21,8 @@ override_dh_auto_install:
 		install -D scripts/_bouncer.sh -t "debian/$$PKG/usr/lib/$$PKG/"; \
 		BACKEND=$$BACKEND envsubst '$$BACKEND' < config/$$BOUNCER.yaml | install -D /dev/stdin "debian/$$PKG/etc/crowdsec/bouncers/$$BOUNCER.yaml"; \
 		BIN="/usr/bin/$$BOUNCER" CFG="/etc/crowdsec/bouncers" envsubst '$$BIN $$CFG' < "config/$$BOUNCER.service" | install -D /dev/stdin "debian/$$PKG/etc/systemd/system/$$BOUNCER.service"; \
+		mkdir -p "debian/$$PKG/usr/sbin/"; \
+		ln -s "/usr/bin/$$BOUNCER" "debian/$$PKG/usr/sbin/$$BOUNCER"; \
 	done
 
 execute_after_dh_fixperms:

--- a/rpm/SPECS/crowdsec-firewall-bouncer.spec
+++ b/rpm/SPECS/crowdsec-firewall-bouncer.spec
@@ -33,6 +33,9 @@ rm -rf %{buildroot}
 
 mkdir -p %{buildroot}%{_bindir}
 install -m 755 %{name} %{buildroot}%{_bindir}/%{name}
+# symlink for compatibility with old versions
+mkdir -p %{buildroot}/usr/sbin
+ln -s %{_bindir}/%{name} %{buildroot}/usr/sbin/%{name}
 
 mkdir -p %{buildroot}/etc/crowdsec/bouncers
 install -m 600 config/%{name}.yaml %{buildroot}/etc/crowdsec/bouncers/%{name}.yaml
@@ -128,6 +131,7 @@ Requires: nftables,gettext
 %files -n %{name}-nftables
 %defattr(-,root,root,-)
 %{_bindir}/%{name}
+/usr/sbin/%{name}
 /usr/lib/%{name}/_bouncer.sh
 %{_unitdir}/%{name}.service
 %config(noreplace) /etc/crowdsec/bouncers/%{name}.yaml

--- a/test/pkg/test_build_rpm.py
+++ b/test/pkg/test_build_rpm.py
@@ -3,6 +3,6 @@ import pytest
 pytestmark = pytest.mark.rpm
 
 
-def test_rpm_build(rpm_package_path, skip_unless_rpm):
+def test_rpm_build(rpm_package, skip_unless_rpm):
     """Test that the package can be built."""
-    assert rpm_package_path.exists(), f'Package {rpm_package_path} not found'
+    assert rpm_package.exists(), f'Package {rpm_package} not found'


### PR DESCRIPTION
The path /usr/sbin/crowdsec-firewall-bouncer was changed for consistency with the other bouncers but it could be hardcoded in systemd unit overrides. This PR provides both /usr/bin and /usr/sbin.

Fixes https://github.com/crowdsecurity/cs-firewall-bouncer/issues/280