### PR TITLE
Remove hard-coded 0600 log file perms

### DIFF
--- a/pkg/cfg/logging.go
+++ b/pkg/cfg/logging.go
@@ -4,12 +4,11 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 
 	log "github.com/sirupsen/logrus"
 	"github.com/sirupsen/logrus/hooks/writer"
 	"gopkg.in/natefinch/lumberjack.v2"
-
-	"github.com/crowdsecurity/go-cs-lib/pkg/logtools"
 )
 
 type LoggingConfig struct {
@@ -27,10 +26,11 @@ func (c *LoggingConfig) LoggerForFile(fileName string) (io.Writer, error) {
 		return os.Stderr, nil
 	}
 
-	logPath, err := logtools.SetLogFilePermissions(c.LogDir, fileName)
-	if err != nil {
-		return nil, err
-	}
+	// logPath, err := logtools.SetLogFilePermissions(c.LogDir, fileName)
+	// if err != nil {
+	// 	return nil, err
+	// }
+	logPath := filepath.Join(c.LogDir, fileName)
 
 	l := &lumberjack.Logger{
 		Filename:   logPath,

--- a/pkg/cfg/logging.go
+++ b/pkg/cfg/logging.go
@@ -26,10 +26,7 @@ func (c *LoggingConfig) LoggerForFile(fileName string) (io.Writer, error) {
 		return os.Stderr, nil
 	}
 
-	// logPath, err := logtools.SetLogFilePermissions(c.LogDir, fileName)
-	// if err != nil {
-	// 	return nil, err
-	// }
+	// rely on lumberjack to create log file during first write
 	logPath := filepath.Join(c.LogDir, fileName)
 
 	l := &lumberjack.Logger{


### PR DESCRIPTION
# Summary

Solves #293. Removes obsolete code from `cfg/logging.go` that sets log file permissions to hard-coded `0600` in every bouncer start. This PR uses `lumberjack`log roller library's native log file creation functionality  instead which preserves existing log file permissions. 

The `logtools.SetLogFilePermissions()` seems to have been copy-pasted from `lumberjack` as a quick-fix to natefinch/lumberjack#82, but the upstream issue has been fixed four years ago. 


