### PR TITLE
Support new nftables configuration design

### DIFF
--- a/pkg/cfg/config.go
+++ b/pkg/cfg/config.go
@@ -8,6 +8,7 @@ import (
 	log "github.com/sirupsen/logrus"
 	"gopkg.in/yaml.v2"
 
+	"github.com/crowdsecurity/cs-firewall-bouncer/pkg/types"
 	"github.com/crowdsecurity/go-cs-lib/csstring"
 	"github.com/crowdsecurity/go-cs-lib/ptr"
 	"github.com/crowdsecurity/go-cs-lib/yamlpatch"
@@ -17,14 +18,6 @@ type PrometheusConfig struct {
 	Enabled       bool   `yaml:"enabled"`
 	ListenAddress string `yaml:"listen_addr"`
 	ListenPort    string `yaml:"listen_port"`
-}
-
-type nftablesFamilyConfig struct {
-	Enabled  *bool  `yaml:"enabled"`
-	SetOnly  bool   `yaml:"set-only"`
-	Table    string `yaml:"table"`
-	Chain    string `yaml:"chain"`
-	Priority int    `yaml:"priority"`
 }
 
 const (
@@ -45,21 +38,21 @@ type BouncerConfig struct {
 	DenyAction      string        `yaml:"deny_action"`
 	DenyLog         bool          `yaml:"deny_log"`
 	DenyLogPrefix   string        `yaml:"deny_log_prefix"`
-	BlacklistsIpv4  string        `yaml:"blacklists_ipv4"`
-	BlacklistsIpv6  string        `yaml:"blacklists_ipv6"`
+	BlacklistsIpv4  string        `yaml:"blacklists_ipv4"` // unused for nftables
+	BlacklistsIpv6  string        `yaml:"blacklists_ipv6"` // unused for nftables
 	SetType         string        `yaml:"ipset_type"`
 	SetSize         int           `yaml:"ipset_size"`
 
 	// specific to iptables, following https://github.com/crowdsecurity/cs-firewall-bouncer/issues/19
 	IptablesChains          []string `yaml:"iptables_chains"`
 	SupportedDecisionsTypes []string `yaml:"supported_decisions_types"`
-	// specific to nftables, following https://github.com/crowdsecurity/cs-firewall-bouncer/issues/74
+	// specific to nftables, following https://github.com/crowdsecurity/cs-firewall-bouncer/issues/74,
+	// https://github.com/crowdsecurity/cs-firewall-bouncer/issues/153
 	Nftables struct {
-		Ipv4 nftablesFamilyConfig `yaml:"ipv4"`
-		Ipv6 nftablesFamilyConfig `yaml:"ipv6"`
+		Enabled *bool                        `yaml:"enabled"`
+		Targets []types.NftablesTargetConfig `yaml:"targets"`
 	} `yaml:"nftables"`
-	NftablesHooks []string `yaml:"nftables_hooks"`
-	PF            struct {
+	PF struct {
 		AnchorName string `yaml:"anchor_name"`
 		BatchSize  int    `yaml:"batch_size"`
 	} `yaml:"pf"`
@@ -154,45 +147,8 @@ func pfConfig(config *BouncerConfig) error {
 }
 
 func nftablesConfig(config *BouncerConfig) error {
-	// deal with defaults in a backward compatible way
-	if config.Nftables.Ipv4.Enabled == nil {
-		config.Nftables.Ipv4.Enabled = ptr.Of(true)
-	}
-
-	if config.Nftables.Ipv6.Enabled == nil {
-		if config.DisableIPV6 {
-			config.Nftables.Ipv4.Enabled = ptr.Of(false)
-		} else {
-			config.Nftables.Ipv6.Enabled = ptr.Of(true)
-		}
-	}
-
-	if *config.Nftables.Ipv4.Enabled {
-		if config.Nftables.Ipv4.Table == "" {
-			config.Nftables.Ipv4.Table = "crowdsec"
-		}
-
-		if config.Nftables.Ipv4.Chain == "" {
-			config.Nftables.Ipv4.Chain = "crowdsec-chain"
-		}
-	}
-
-	if *config.Nftables.Ipv6.Enabled {
-		if config.Nftables.Ipv6.Table == "" {
-			config.Nftables.Ipv6.Table = "crowdsec6"
-		}
-
-		if config.Nftables.Ipv6.Chain == "" {
-			config.Nftables.Ipv6.Chain = "crowdsec6-chain"
-		}
-	}
-
-	if !*config.Nftables.Ipv4.Enabled && !*config.Nftables.Ipv6.Enabled {
-		return fmt.Errorf("both IPv4 and IPv6 disabled, doing nothing")
-	}
-
-	if config.NftablesHooks == nil || len(config.NftablesHooks) == 0 {
-		config.NftablesHooks = []string{"input"}
+	if config.Nftables.Enabled == nil {
+		config.Nftables.Enabled = ptr.Of(false)
 	}
 
 	return nil

--- a/pkg/nftables/metrics.go
+++ b/pkg/nftables/metrics.go
@@ -61,15 +61,11 @@ func (c *nftContext) collectDroppedPackets(path string, chain string) (int, int,
 }
 
 func (c *nftContext) ipFamily() string {
-	if c.version == "v4" {
-		return "ip"
-	}
-
-	return "ip6"
+	return c.version
 }
 
 func (c *nftContext) collectActiveBannedIPs(path string) (int, error) {
-	cmd := exec.Command(path, "-j", "list", "set", c.ipFamily(), c.tableName, c.blacklists)
+	cmd := exec.Command(path, "-j", "list", "set", c.ipFamily(), c.tableName, c.blacklist)
 
 	out, err := cmd.CombinedOutput()
 	if err != nil {
@@ -89,37 +85,33 @@ func (c *nftContext) collectActiveBannedIPs(path string) (int, error) {
 	return ret, nil
 }
 
-func (c *nftContext) collectDropped(path string, hooks []string) (int, int, int) {
+func (c *nftContext) collectDropped(path string, droppedPackets *int, droppedBytes *int, banned *int) {
 	if c.conn == nil {
-		return 0, 0, 0
+		return
 	}
-
-	var droppedPackets, droppedBytes, banned int
 
 	if c.setOnly {
 		pkt, byt, err := c.collectDroppedPackets(path, c.chainName)
 		if err != nil {
-			log.Errorf("can't collect dropped packets for ip%s from nft: %s", c.version, err)
+			log.Errorf("can't collect dropped packets for %s from nft: %s", c.version, err)
 		}
-		droppedPackets += pkt
-		droppedBytes += byt
+		*droppedPackets += pkt
+		*droppedBytes += byt
 	} else {
-		for _, hook := range hooks {
-			pkt, byt, err := c.collectDroppedPackets(path, c.chainName+"-"+hook)
-			if err != nil {
-				log.Errorf("can't collect dropped packets for ip%s from nft: %s", c.version, err)
-			}
-			droppedPackets += pkt
-			droppedBytes += byt
+		pkt, byt, err := c.collectDroppedPackets(path, c.chainName+"-"+c.hook)
+		if err != nil {
+			log.Errorf("can't collect dropped packets for %s from nft: %s", c.version, err)
 		}
+		*droppedPackets += pkt
+		*droppedBytes += byt
 	}
 
-	banned, err := c.collectActiveBannedIPs(path)
+	tmpBanned, err := c.collectActiveBannedIPs(path)
 	if err != nil {
-		log.Errorf("can't collect total banned IPs for ip%s from nft: %s", c.version, err)
+		log.Errorf("can't collect total banned IPs for %s from nft: %s", c.version, err)
+	} else {
+		*banned += tmpBanned
 	}
-
-	return droppedPackets, droppedBytes, banned
 }
 
 func (n *nft) CollectMetrics() {
@@ -139,8 +131,16 @@ func (n *nft) CollectMetrics() {
 	t := time.NewTicker(metrics.MetricCollectionInterval)
 
 	for range t.C {
-		ip4DroppedPackets, ip4DroppedBytes, bannedIP4 := n.v4.collectDropped(path, n.Hooks)
-		ip6DroppedPackets, ip6DroppedBytes, bannedIP6 := n.v6.collectDropped(path, n.Hooks)
+		var ip4DroppedPackets, ip4DroppedBytes, bannedIP4,
+			ip6DroppedPackets, ip6DroppedBytes, bannedIP6 int
+
+		for _, context := range n.contexts {
+			if context.version == "ip" {
+				context.collectDropped(path, &ip4DroppedPackets, &ip4DroppedBytes, &bannedIP4)
+			} else if context.version == "ip6" {
+				context.collectDropped(path, &ip6DroppedPackets, &ip6DroppedBytes, &bannedIP6)
+			}
+		}
 
 		metrics.TotalDroppedPackets.Set(float64(ip4DroppedPackets + ip6DroppedPackets))
 		metrics.TotalDroppedBytes.Set(float64(ip6DroppedBytes + ip4DroppedBytes))

--- a/pkg/nftables/nftables_context.go
+++ b/pkg/nftables/nftables_context.go
@@ -16,7 +16,7 @@ import (
 
 	"github.com/crowdsecurity/go-cs-lib/slicetools"
 
-	"github.com/crowdsecurity/cs-firewall-bouncer/pkg/cfg"
+	"github.com/crowdsecurity/cs-firewall-bouncer/pkg/types"
 )
 
 var HookNameToHookID = map[string]nftables.ChainHook{
@@ -29,16 +29,17 @@ var HookNameToHookID = map[string]nftables.ChainHook{
 }
 
 type nftContext struct {
+	version       string
 	conn          *nftables.Conn
 	set           *nftables.Set
 	table         *nftables.Table
 	tableFamily   nftables.TableFamily
 	typeIPAddr    nftables.SetDatatype
-	version       string
 	payloadOffset uint32
 	payloadLength uint32
 	priority      int
-	blacklists    string
+	blacklist     string
+	hook          string
 	chainName     string
 	tableName     string
 	setOnly       bool
@@ -49,60 +50,43 @@ func reprIP(ip []byte) string {
 	return net.IP(ip).String()
 }
 
-func NewNFTV4Context(config *cfg.BouncerConfig) *nftContext {
-	if !*config.Nftables.Ipv4.Enabled {
-		log.Debug("nftables: ipv4 disabled")
-
-		return &nftContext{}
+func NewNFTContext(target *types.NftablesTargetConfig) *nftContext {
+	var tableFamily nftables.TableFamily
+	if target.Family == "ip" {
+		tableFamily = nftables.TableFamilyIPv4
+	} else if target.Family == "ip6" {
+		tableFamily = nftables.TableFamilyIPv6
+	} else if target.Family == "inet" {
+		tableFamily = nftables.TableFamilyINet
 	}
 
-	log.Debug("nftables: ipv4 enabled")
+	var setIpAddrType nftables.SetDatatype
+	var payloadOffset, payloadLength uint32
+	if target.Protocol == "ip" {
+		setIpAddrType = nftables.TypeIPAddr
+		payloadOffset, payloadLength = 12, 4
+	} else if target.Protocol == "ip6" {
+		setIpAddrType = nftables.TypeIP6Addr
+		payloadOffset, payloadLength = 8, 16
+	}
 
 	ret := &nftContext{
+		version:       target.Protocol,
 		conn:          &nftables.Conn{},
-		version:       "v4",
-		tableFamily:   nftables.TableFamilyIPv4,
-		typeIPAddr:    nftables.TypeIPAddr,
-		payloadOffset: 12,
-		payloadLength: 4,
-		tableName:     config.Nftables.Ipv4.Table,
-		chainName:     config.Nftables.Ipv4.Chain,
-		blacklists:    config.BlacklistsIpv4,
-		setOnly:       config.Nftables.Ipv4.SetOnly,
-		priority:      config.Nftables.Ipv4.Priority,
+		tableFamily:   tableFamily,
+		typeIPAddr:    setIpAddrType,
+		payloadOffset: payloadOffset,
+		payloadLength: payloadLength,
+		tableName:     target.Table,
+		chainName:     target.Chain,
+		hook:          target.Hook,
+		blacklist:     target.Blacklist,
+		setOnly:       target.SetOnly,
+		priority:      target.Priority,
 	}
 
-	log.Debugf("nftables: ipv4: %t, table: %s, chain: %s, blacklist: %s, set-only: %t",
-		*config.Nftables.Ipv4.Enabled, ret.tableName, ret.chainName, ret.blacklists, ret.setOnly)
-
-	return ret
-}
-
-func NewNFTV6Context(config *cfg.BouncerConfig) *nftContext {
-	if !*config.Nftables.Ipv6.Enabled {
-		log.Debug("nftables: ipv6 disabled")
-
-		return &nftContext{}
-	}
-
-	log.Debug("nftables: ipv6 enabled")
-
-	ret := &nftContext{
-		conn:          &nftables.Conn{},
-		version:       "v6",
-		tableFamily:   nftables.TableFamilyIPv6,
-		typeIPAddr:    nftables.TypeIP6Addr,
-		payloadOffset: 8,
-		payloadLength: 16,
-		tableName:     config.Nftables.Ipv6.Table,
-		chainName:     config.Nftables.Ipv6.Chain,
-		blacklists:    config.BlacklistsIpv6,
-		setOnly:       config.Nftables.Ipv6.SetOnly,
-		priority:      config.Nftables.Ipv6.Priority,
-	}
-
-	log.Debugf("nftables: ipv6: %t, table6: %s, chain6: %s, blacklist: %s, set-only6: %t",
-		*config.Nftables.Ipv6.Enabled, ret.tableName, ret.chainName, ret.blacklists, ret.setOnly)
+	log.Debugf("nftables: %s, table: %s, chain: %s, blacklist: %s, set-only: %t",
+		target.Protocol, target.Table, target.Chain, ret.blacklist, ret.setOnly)
 
 	return ret
 }
@@ -129,19 +113,19 @@ func (c *nftContext) initSetOnly() error {
 	var err error
 
 	// Use existing nftables configuration
-	log.Debugf("nftables: ip%s set-only", c.version)
+	log.Debugf("nftables: %s set-only", c.version)
 
 	c.table, err = c.lookupTable()
 	if err != nil {
 		return err
 	}
 
-	set, err := c.conn.GetSetByName(c.table, c.blacklists)
+	set, err := c.conn.GetSetByName(c.table, c.blacklist)
 	if err != nil {
-		log.Debugf("nftables: could not find ip%s blacklist '%s' in table '%s': creating...", c.version, c.blacklists, c.tableName)
+		log.Debugf("nftables: could not find %s blacklist '%s' in table '%s': creating...", c.version, c.blacklist, c.tableName)
 
 		set = &nftables.Set{
-			Name:         c.blacklists,
+			Name:         c.blacklist,
 			Table:        c.table,
 			KeyType:      c.typeIPAddr,
 			KeyByteOrder: binaryutil.BigEndian,
@@ -158,13 +142,13 @@ func (c *nftContext) initSetOnly() error {
 	}
 
 	c.set = set
-	log.Debugf("nftables: ip%s set '%s' configured", c.version, c.blacklists)
+	log.Debugf("nftables: %s set '%s' configured", c.version, c.blacklist)
 
 	return nil
 }
 
-func (c *nftContext) initOwnTable(hooks []string, denyLog bool, denyLogPrefix string, denyAction string) error {
-	log.Debugf("nftables: ip%s own table", c.version)
+func (c *nftContext) initOwnTable(denyLog bool, denyLogPrefix string, denyAction string) error {
+	log.Debugf("nftables: %s own table", c.version)
 
 	c.table = c.conn.AddTable(&nftables.Table{
 		Family: c.tableFamily,
@@ -172,7 +156,7 @@ func (c *nftContext) initOwnTable(hooks []string, denyLog bool, denyLogPrefix st
 	})
 
 	set := &nftables.Set{
-		Name:         c.blacklists,
+		Name:         c.blacklist,
 		Table:        c.table,
 		KeyType:      c.typeIPAddr,
 		KeyByteOrder: binaryutil.BigEndian,
@@ -185,47 +169,45 @@ func (c *nftContext) initOwnTable(hooks []string, denyLog bool, denyLogPrefix st
 
 	c.set = set
 
-	for _, hook := range hooks {
-		hooknum := HookNameToHookID[hook]
-		priority := nftables.ChainPriority(c.priority)
-		chain := c.conn.AddChain(&nftables.Chain{
-			Name:     c.chainName + "-" + hook,
-			Table:    c.table,
-			Type:     nftables.ChainTypeFilter,
-			Hooknum:  &hooknum,
-			Priority: &priority,
-		})
+	hooknum := HookNameToHookID[c.hook]
+	priority := nftables.ChainPriority(c.priority)
+	chain := c.conn.AddChain(&nftables.Chain{
+		Name:     c.chainName + "-" + c.hook,
+		Table:    c.table,
+		Type:     nftables.ChainTypeFilter,
+		Hooknum:  &hooknum,
+		Priority: &priority,
+	})
 
-		log.Debugf("nftables: ip%s chain '%s' created", c.version, chain.Name)
-		r, err := c.createRule(chain, set, denyLog, denyLogPrefix, denyAction)
-		if err != nil {
-			return err
-		}
-		c.conn.AddRule(r)
+	log.Debugf("nftables: %s chain '%s' created", c.version, chain.Name)
+	r, err := c.createRule(chain, set, denyLog, denyLogPrefix, denyAction)
+	if err != nil {
+		return err
 	}
+	c.conn.AddRule(r)
 
 	if err := c.conn.Flush(); err != nil {
 		return err
 	}
 
-	log.Debugf("nftables: ip%s table created", c.version)
+	log.Debugf("nftables: %s table created", c.version)
 
 	return nil
 }
 
-func (c *nftContext) init(hooks []string, denyLog bool, denyLogPrefix string, denyAction string) error {
+func (c *nftContext) init(denyLog bool, denyLogPrefix string, denyAction string) error {
 	if c.conn == nil {
 		return nil
 	}
 
-	log.Debugf("nftables: ip%s init starting", c.version)
+	log.Debugf("nftables: %s init starting", c.version)
 
 	var err error
 
 	if c.setOnly {
 		err = c.initSetOnly()
 	} else {
-		err = c.initOwnTable(hooks, denyLog, denyLogPrefix, denyAction)
+		err = c.initOwnTable(denyLog, denyLogPrefix, denyAction)
 	}
 
 	if err != nil && strings.Contains(err.Error(), "out of range") {
@@ -309,7 +291,7 @@ func (c *nftContext) createRule(chain *nftables.Chain, set *nftables.Set,
 
 func (c *nftContext) deleteElementChunk(els []nftables.SetElement) error {
 	if err := c.conn.SetDeleteElements(c.set, els); err != nil {
-		return fmt.Errorf("failed to remove ip%s elements from set: %w", c.version, err)
+		return fmt.Errorf("failed to remove %s elements from set: %w", c.version, err)
 	}
 	if err := c.conn.Flush(); err != nil {
 		if len(els) == 1 {
@@ -342,14 +324,14 @@ func (c *nftContext) deleteElements(els []nftables.SetElement) error {
 
 func (c *nftContext) addElements(els []nftables.SetElement) error {
 	for _, chunk := range slicetools.Chunks(els, chunkSize) {
-		log.Debugf("adding %d ip%s elements to set", len(chunk), c.version)
+		log.Debugf("adding %d %s elements to set", len(chunk), c.version)
 
 		if err := c.conn.SetAddElements(c.set, chunk); err != nil {
-			return fmt.Errorf("failed to add ip%s elements to set: %w", c.version, err)
+			return fmt.Errorf("failed to add %s elements to set: %w", c.version, err)
 		}
 
 		if err := c.conn.Flush(); err != nil {
-			return fmt.Errorf("failed to flush ip%s conn: %w", c.version, err)
+			return fmt.Errorf("failed to flush %s conn: %w", c.version, err)
 		}
 	}
 

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -12,3 +12,14 @@ type Backend interface {
 	Commit() error
 	CollectMetrics()
 }
+
+type NftablesTargetConfig struct {
+	Blacklist string `yaml:"blacklist"`
+	SetOnly   bool   `yaml:"set-only"`
+	Table     string `yaml:"table"`
+	Chain     string `yaml:"chain"`
+	Family    string `yaml:"family"`
+	Protocol  string `yaml:"protocol"`
+	Hook      string `yaml:"hook"`
+	Priority  int    `yaml:"priority"`
+}


### PR DESCRIPTION
As proposed at [issue 153](https://github.com/crowdsecurity/cs-firewall-bouncer/issues/153#issuecomment-1061142458), I have implemented the following configuration design:
```yaml
nftables:
    enabled: true
    targets:
    - blacklist: crowdsec-blacklist4
      set-only: false
      table: crowdsec-inet
      chain: crowdsec-input
      family: inet
      protocol: ip
      hook: input
    - blacklist: crowdsec-blacklist6
      set-only: false
      table: crowdsec-inet
      chain: crowdsec-input
      family: inet
      protocol: ip6
      hook: input
```

I have already tested it on my crowdsec station, however if there still any issues please let me know!