### PR TITLE
Change log message "failed to flush" from info -> debug

### DIFF
--- a/pkg/nftables/nftables_context.go
+++ b/pkg/nftables/nftables_context.go
@@ -316,7 +316,7 @@ func (c *nftContext) deleteElementChunk(els []nftables.SetElement) error {
 			log.Debugf("deleting %s, failed to flush: %s", reprIP(els[0].Key), err)
 			return nil
 		}
-		log.Infof("failed to flush chunk of %d elements, will retry each one: %s", len(els), err)
+		log.Debugf("failed to flush chunk of %d elements, will retry each one: %s", len(els), err)
 		for _, el := range els {
 			if err := c.deleteElementChunk([]nftables.SetElement{el}); err != nil {
 				return err


### PR DESCRIPTION
As mentioned in https://github.com/crowdsecurity/cs-firewall-bouncer/issues/316