### PR TITLE
Makefile: use GO macro if set, to check for version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,9 @@
 BUILD_REQUIRE_GO_MAJOR ?= 1
 BUILD_REQUIRE_GO_MINOR ?= 20
 
-GOCMD=go
-GOBUILD=$(GOCMD) build
-GOTEST=$(GOCMD) test
+GO = go
+GOBUILD = $(GO) build
+GOTEST = $(GO) test
 
 BINARY_NAME=crowdsec-firewall-bouncer
 TARBALL_NAME=$(BINARY_NAME).tgz
@@ -91,7 +91,7 @@ RELDIR = $(BINARY_NAME)-$(BUILD_VERSION)
 
 .PHONY: vendor
 vendor: vendor-remove
-	$(GOCMD) mod vendor
+	$(GO) mod vendor
 	tar czf vendor.tgz vendor
 	tar --create --auto-compress --file=$(RELDIR)-vendor.tar.xz vendor
 

--- a/mk/goversion.mk
+++ b/mk/goversion.mk
@@ -1,5 +1,5 @@
 
-BUILD_GOVERSION = $(subst go,,$(shell go env GOVERSION))
+BUILD_GOVERSION = $(subst go,,$(shell $(GO) env GOVERSION))
 
 go_major_minor = $(subst ., ,$(BUILD_GOVERSION))
 GO_MAJOR_VERSION = $(word 1, $(go_major_minor))
@@ -9,7 +9,7 @@ GO_VERSION_VALIDATION_ERR_MSG = Golang version ($(BUILD_GOVERSION)) is not suppo
 
 
 .PHONY: goversion
-goversion: $(if $(findstring devel,$(shell go env GOVERSION)),goversion_devel,goversion_check)
+goversion: $(if $(findstring devel,$(shell $(GO) env GOVERSION)),goversion_devel,goversion_check)
 
 
 .PHONY: goversion_devel


### PR DESCRIPTION
sometimes it's necessary to set the path to bin/go in order to build (i.e. to /usr/local/bin/go121)