### PR TITLE
add back missing logging rules

### DIFF
--- a/pkg/iptables/iptables.go
+++ b/pkg/iptables/iptables.go
@@ -56,22 +56,26 @@ func NewIPTables(config *cfg.BouncerConfig) (types.Backend, error) {
 	v6Sets := make(map[string]*ipsetcmd.IPSet)
 
 	ipv4Ctx := &ipTablesContext{
-		version:    "v4",
-		SetName:    config.BlacklistsIpv4,
-		SetType:    config.SetType,
-		SetSize:    config.SetSize,
-		Chains:     []string{},
-		defaultSet: defaultSet,
-		target:     target,
+		version:        "v4",
+		SetName:        config.BlacklistsIpv4,
+		SetType:        config.SetType,
+		SetSize:        config.SetSize,
+		Chains:         []string{},
+		defaultSet:     defaultSet,
+		target:         target,
+		loggingEnabled: config.DenyLog,
+		loggingPrefix:  config.DenyLogPrefix,
 	}
 	ipv6Ctx := &ipTablesContext{
-		version:    "v6",
-		SetName:    config.BlacklistsIpv6,
-		SetType:    config.SetType,
-		SetSize:    config.SetSize,
-		Chains:     []string{},
-		defaultSet: defaultSet,
-		target:     target,
+		version:        "v6",
+		SetName:        config.BlacklistsIpv6,
+		SetType:        config.SetType,
+		SetSize:        config.SetSize,
+		Chains:         []string{},
+		defaultSet:     defaultSet,
+		target:         target,
+		loggingEnabled: config.DenyLog,
+		loggingPrefix:  config.DenyLogPrefix,
 	}
 
 	ipv4Ctx.iptablesSaveBin, err = exec.LookPath("iptables-save")


### PR DESCRIPTION
Iptables logging configuration was ignored since the refactoring to split rules per origin.

Because we now create multiple sets/rules based on the origin, the way we log has changed: instead of matching twice on the set to see if iptables should log something, change the target of the rules we create to jump to a dedicated logging chain that will log and perform the action specified in the configuration. 