### PR TITLE
Disable timeouts for Edgerouter 10x ipsets

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,7 @@ venv/
 /rpm/RPMS
 /rpm/SOURCES/*.tar.gz
 /rpm/SRPMS
+
+# nix generated dirs
+.direnv
+.devenv

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,25 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1739736696,
+        "narHash": "sha256-zON2GNBkzsIyALlOCFiEBcIjI4w38GYOb+P+R4S8Jsw=",
+        "rev": "d74a2335ac9c133d6bbec9fc98d91a77f1604c1f",
+        "revCount": 754461,
+        "type": "tarball",
+        "url": "https://api.flakehub.com/f/pinned/NixOS/nixpkgs/0.1.754461%2Brev-d74a2335ac9c133d6bbec9fc98d91a77f1604c1f/01951426-5a87-7b75-8413-1a0d9ec5ff04/source.tar.gz"
+      },
+      "original": {
+        "type": "tarball",
+        "url": "https://flakehub.com/f/NixOS/nixpkgs/0.1.%2A.tar.gz"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,40 @@
+{
+  description = "A Nix-flake-based Go 1.22 development environment";
+
+  inputs.nixpkgs.url = "https://flakehub.com/f/NixOS/nixpkgs/0.1.*.tar.gz";
+
+  outputs = { self, nixpkgs }:
+    let
+      goVersion = 24; # Change this to update the whole stack
+
+      supportedSystems = [ "x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin" ];
+      forEachSupportedSystem = f: nixpkgs.lib.genAttrs supportedSystems (system: f {
+        pkgs = import nixpkgs {
+          inherit system;
+          overlays = [ self.overlays.default ];
+        };
+      });
+    in
+    {
+      overlays.default = final: prev: {
+        go = final."go_1_${toString goVersion}";
+      };
+
+      devShells = forEachSupportedSystem ({ pkgs }: {
+        default = pkgs.mkShell {
+          packages = with pkgs; [
+            # go (version is specified by overlay)
+            go
+
+            # goimports, godoc, etc.
+            gotools
+
+            # https://github.com/golangci/golangci-lint
+            golangci-lint
+            golangci-lint-langserver
+            gopls
+          ];
+        };
+      });
+    };
+}

--- a/pkg/cfg/config.go
+++ b/pkg/cfg/config.go
@@ -35,19 +35,20 @@ const (
 )
 
 type BouncerConfig struct {
-	Mode            string        `yaml:"mode"`    // ipset,iptables,tc
-	PidDir          string        `yaml:"pid_dir"` // unused
-	UpdateFrequency string        `yaml:"update_frequency"`
-	Daemon          *bool         `yaml:"daemonize"` // unused
-	Logging         LoggingConfig `yaml:",inline"`
-	DisableIPV6     bool          `yaml:"disable_ipv6"`
-	DenyAction      string        `yaml:"deny_action"`
-	DenyLog         bool          `yaml:"deny_log"`
-	DenyLogPrefix   string        `yaml:"deny_log_prefix"`
-	BlacklistsIpv4  string        `yaml:"blacklists_ipv4"`
-	BlacklistsIpv6  string        `yaml:"blacklists_ipv6"`
-	SetType         string        `yaml:"ipset_type"`
-	SetSize         int           `yaml:"ipset_size"`
+	Mode               string        `yaml:"mode"`    // ipset,iptables,tc
+	PidDir             string        `yaml:"pid_dir"` // unused
+	UpdateFrequency    string        `yaml:"update_frequency"`
+	Daemon             *bool         `yaml:"daemonize"` // unused
+	Logging            LoggingConfig `yaml:",inline"`
+	DisableIPV6        bool          `yaml:"disable_ipv6"`
+	DenyAction         string        `yaml:"deny_action"`
+	DenyLog            bool          `yaml:"deny_log"`
+	DenyLogPrefix      string        `yaml:"deny_log_prefix"`
+	BlacklistsIpv4     string        `yaml:"blacklists_ipv4"`
+	BlacklistsIpv6     string        `yaml:"blacklists_ipv6"`
+	SetType            string        `yaml:"ipset_type"`
+	SetSize            int           `yaml:"ipset_size"`
+	SetDisableTimeouts bool          `yaml:"ipset_disable_timeouts"`
 
 	// specific to iptables, following https://github.com/crowdsecurity/cs-firewall-bouncer/issues/19
 	IptablesChains          []string `yaml:"iptables_chains"`

--- a/pkg/ipsetcmd/ipset.go
+++ b/pkg/ipsetcmd/ipset.go
@@ -16,10 +16,11 @@ type IPSet struct {
 }
 
 type CreateOptions struct {
-	Timeout string
-	MaxElem string
-	Family  string
-	Type    string
+	Timeout         string
+	MaxElem         string
+	Family          string
+	Type            string
+	DisableTimeouts bool
 }
 
 const ipsetBinary = "ipset"
@@ -35,8 +36,7 @@ func NewIPSet(setName string) (*IPSet, error) {
 	}, nil
 }
 
-//Wraps all the ipset commands
-
+// Wraps all the ipset commands
 func (i *IPSet) Create(opts CreateOptions) error {
 	cmdArgs := []string{"create", i.setName}
 
@@ -44,7 +44,7 @@ func (i *IPSet) Create(opts CreateOptions) error {
 		cmdArgs = append(cmdArgs, opts.Type)
 	}
 
-	if opts.Timeout != "" {
+	if opts.Timeout != "" && !opts.DisableTimeouts {
 		cmdArgs = append(cmdArgs, "timeout", opts.Timeout)
 	}
 
@@ -61,7 +61,6 @@ func (i *IPSet) Create(opts CreateOptions) error {
 	log.Debugf("ipset create command: %v", cmd.String())
 
 	out, err := cmd.CombinedOutput()
-
 	if err != nil {
 		return fmt.Errorf("error creating ipset: %s", out)
 	}
@@ -74,7 +73,6 @@ func (i *IPSet) Add(entry string) error {
 
 	log.Debugf("ipset add command: %v", cmd.String())
 	out, err := cmd.CombinedOutput()
-
 	if err != nil {
 		return fmt.Errorf("error creating ipset: %s", out)
 	}
@@ -87,7 +85,6 @@ func (i *IPSet) DeleteEntry(entry string) error {
 
 	log.Debugf("ipset delete entry command: %v", cmd.String())
 	out, err := cmd.CombinedOutput()
-
 	if err != nil {
 		return fmt.Errorf("error creating ipset: %s", out)
 	}
@@ -100,7 +97,6 @@ func (i *IPSet) List() ([]string, error) {
 
 	log.Debugf("ipset list command: %v", cmd.String())
 	out, err := cmd.CombinedOutput()
-
 	if err != nil {
 		return nil, fmt.Errorf("error listing ipset: %s", out)
 	}
@@ -113,7 +109,6 @@ func (i *IPSet) Flush() error {
 
 	log.Debugf("ipset flush command: %v", cmd.String())
 	out, err := cmd.CombinedOutput()
-
 	if err != nil {
 		return fmt.Errorf("error flushing ipset: %s", out)
 	}
@@ -126,7 +121,6 @@ func (i *IPSet) Destroy() error {
 
 	log.Debugf("ipset destroy command: %v", cmd.String())
 	out, err := cmd.CombinedOutput()
-
 	if err != nil {
 		return fmt.Errorf("error destroying ipset: %s", out)
 	}
@@ -139,7 +133,6 @@ func (i *IPSet) Rename(toSetName string) error {
 
 	log.Debugf("ipset rename command: %v", cmd.String())
 	out, err := cmd.CombinedOutput()
-
 	if err != nil {
 		return fmt.Errorf("error renaming ipset: %s", out)
 	}
@@ -154,7 +147,6 @@ func (i *IPSet) Test(entry string) error {
 
 	log.Debugf("ipset test command: %v", cmd.String())
 	out, err := cmd.CombinedOutput()
-
 	if err != nil {
 		return fmt.Errorf("error testing ipset: %s", out)
 	}
@@ -167,7 +159,6 @@ func (i *IPSet) Save() ([]string, error) {
 
 	log.Debugf("ipset save command: %v", cmd.String())
 	out, err := cmd.CombinedOutput()
-
 	if err != nil {
 		return nil, fmt.Errorf("error saving ipset: %s", out)
 	}
@@ -179,7 +170,6 @@ func (i *IPSet) Restore(filename string) error {
 
 	log.Debugf("ipset restore command: %v", cmd.String())
 	out, err := cmd.CombinedOutput()
-
 	if err != nil {
 		return fmt.Errorf("error restoring ipset: %s", out)
 	}
@@ -192,7 +182,6 @@ func (i *IPSet) Swap(toSetName string) error {
 
 	log.Debugf("ipset swap command: %v", cmd.String())
 	out, err := cmd.CombinedOutput()
-
 	if err != nil {
 		return fmt.Errorf("error swapping ipset: %s", out)
 	}
@@ -219,7 +208,6 @@ func (i *IPSet) Len() int {
 
 	log.Debugf("ipset list command: %v", cmd.String())
 	out, err := cmd.CombinedOutput()
-
 	if err != nil {
 		return 0
 	}
@@ -241,14 +229,12 @@ func (i *IPSet) Len() int {
 	return 0
 }
 
-//Helpers
-
+// Helpers
 func GetSetsStartingWith(name string) (map[string]*IPSet, error) {
 	cmd := exec.Command(ipsetBinary, "list", "-name")
 
 	log.Debugf("ipset list command: %v", cmd.String())
 	out, err := cmd.CombinedOutput()
-
 	if err != nil {
 		return nil, fmt.Errorf("error listing ipset: %s", out)
 	}

--- a/pkg/ipsetcmd/ipset.go
+++ b/pkg/ipsetcmd/ipset.go
@@ -36,7 +36,7 @@ func NewIPSet(setName string) (*IPSet, error) {
 	}, nil
 }
 
-// Wraps all the ipset commands
+// Wraps all the ipset commands.
 func (i *IPSet) Create(opts CreateOptions) error {
 	cmdArgs := []string{"create", i.setName}
 
@@ -229,7 +229,7 @@ func (i *IPSet) Len() int {
 	return 0
 }
 
-// Helpers
+// Helpers.
 func GetSetsStartingWith(name string) (map[string]*IPSet, error) {
 	cmd := exec.Command(ipsetBinary, "list", "-name")
 

--- a/pkg/iptables/iptables.go
+++ b/pkg/iptables/iptables.go
@@ -34,7 +34,6 @@ func NewIPTables(config *cfg.BouncerConfig) (types.Backend, error) {
 	ret := &iptables{}
 
 	defaultSet, err := ipsetcmd.NewIPSet("")
-
 	if err != nil {
 		return nil, err
 	}
@@ -56,26 +55,28 @@ func NewIPTables(config *cfg.BouncerConfig) (types.Backend, error) {
 	v6Sets := make(map[string]*ipsetcmd.IPSet)
 
 	ipv4Ctx := &ipTablesContext{
-		version:        "v4",
-		SetName:        config.BlacklistsIpv4,
-		SetType:        config.SetType,
-		SetSize:        config.SetSize,
-		Chains:         []string{},
-		defaultSet:     defaultSet,
-		target:         target,
-		loggingEnabled: config.DenyLog,
-		loggingPrefix:  config.DenyLogPrefix,
+		version:              "v4",
+		SetName:              config.BlacklistsIpv4,
+		SetType:              config.SetType,
+		SetSize:              config.SetSize,
+		ipsetDisableTimeouts: config.SetDisableTimeouts,
+		Chains:               []string{},
+		defaultSet:           defaultSet,
+		target:               target,
+		loggingEnabled:       config.DenyLog,
+		loggingPrefix:        config.DenyLogPrefix,
 	}
 	ipv6Ctx := &ipTablesContext{
-		version:        "v6",
-		SetName:        config.BlacklistsIpv6,
-		SetType:        config.SetType,
-		SetSize:        config.SetSize,
-		Chains:         []string{},
-		defaultSet:     defaultSet,
-		target:         target,
-		loggingEnabled: config.DenyLog,
-		loggingPrefix:  config.DenyLogPrefix,
+		version:              "v6",
+		SetName:              config.BlacklistsIpv6,
+		SetType:              config.SetType,
+		SetSize:              config.SetSize,
+		ipsetDisableTimeouts: config.SetDisableTimeouts,
+		Chains:               []string{},
+		defaultSet:           defaultSet,
+		target:               target,
+		loggingEnabled:       config.DenyLog,
+		loggingPrefix:        config.DenyLogPrefix,
 	}
 
 	ipv4Ctx.iptablesSaveBin, err = exec.LookPath("iptables-save")
@@ -96,8 +97,8 @@ func NewIPTables(config *cfg.BouncerConfig) (types.Backend, error) {
 			return nil, errors.New("unable to find iptables")
 		}
 
-		//Try to "adopt" any leftover sets from a previous run if we crashed
-		//They will get flushed/deleted just after
+		// Try to "adopt" any leftover sets from a previous run if we crashed
+		// They will get flushed/deleted just after
 		v4Sets, _ = ipsetcmd.GetSetsStartingWith(config.BlacklistsIpv4)
 		v6Sets, _ = ipsetcmd.GetSetsStartingWith(config.BlacklistsIpv6)
 

--- a/pkg/iptables/iptables_context.go
+++ b/pkg/iptables/iptables_context.go
@@ -313,7 +313,7 @@ func (ctx *ipTablesContext) commit() error {
 			}
 		}
 
-		addCmd := ""
+		var addCmd string
 		if ctx.ipsetDisableTimeouts {
 			addCmd = fmt.Sprintf("add %s %s -exist\n", set.Name(), *decision.Value)
 		} else {

--- a/pkg/iptables/iptables_context.go
+++ b/pkg/iptables/iptables_context.go
@@ -18,30 +18,35 @@ import (
 	"github.com/crowdsecurity/cs-firewall-bouncer/pkg/ipsetcmd"
 )
 
-const chainName = "CROWDSEC_CHAIN"
-const loggingChainName = "CROWDSEC_LOG"
+const (
+	chainName        = "CROWDSEC_CHAIN"
+	loggingChainName = "CROWDSEC_LOG"
+	maxBanSeconds    = 2147483
+	defaultTimeout   = "300"
+)
 
 type ipTablesContext struct {
-	version          string
-	iptablesBin      string
-	iptablesSaveBin  string
-	SetName          string // crowdsec-netfilter
-	SetType          string
-	SetSize          int
-	ipsetContentOnly bool
-	Chains           []string
+	version              string
+	iptablesBin          string
+	iptablesSaveBin      string
+	SetName              string // crowdsec-netfilter
+	SetType              string
+	SetSize              int
+	ipsetContentOnly     bool
+	ipsetDisableTimeouts bool
+	Chains               []string
 
 	target string
 
 	ipsets     map[string]*ipsetcmd.IPSet
-	defaultSet *ipsetcmd.IPSet //This one is only used to restore the content, as the file will contain the name of the set for each decision
+	defaultSet *ipsetcmd.IPSet // This one is only used to restore the content, as the file will contain the name of the set for each decision
 
 	toAdd []*models.Decision
 	toDel []*models.Decision
 
-	//To avoid issues with set name length (ipsest name length is limited to 31 characters)
-	//Store the origin of the decisions, and use the index in the slice as the name
-	//This is not stable (ie, between two runs, the index of a set can change), but it's (probably) not an issue
+	// To avoid issues with set name length (ipsest name length is limited to 31 characters)
+	// Store the origin of the decisions, and use the index in the slice as the name
+	// This is not stable (ie, between two runs, the index of a set can change), but it's (probably) not an issue
 	originSetMapping []string
 
 	loggingEnabled bool
@@ -113,7 +118,6 @@ func (ctx *ipTablesContext) setupChain() {
 }
 
 func (ctx *ipTablesContext) deleteChain() {
-
 	for _, chain := range ctx.Chains {
 
 		cmd := []string{"-D", chain, "-j", chainName}
@@ -189,9 +193,7 @@ func (ctx *ipTablesContext) createRule(setName string) {
 }
 
 func (ctx *ipTablesContext) commit() error {
-
 	tmpFile, err := os.CreateTemp("", "cs-firewall-bouncer-ipset-")
-
 	if err != nil {
 		return err
 	}
@@ -209,9 +211,9 @@ func (ctx *ipTablesContext) commit() error {
 		var set *ipsetcmd.IPSet
 		var ok bool
 
-		//Decisions coming from lists will have "lists" as origin, and the scenario will be the list name
-		//We use those to build a custom origin because we want to track metrics per list
-		//In case of other origin (crowdsec, cscli, ...), we do not really care about the scenario, it would be too noisy
+		// Decisions coming from lists will have "lists" as origin, and the scenario will be the list name
+		// We use those to build a custom origin because we want to track metrics per list
+		// In case of other origin (crowdsec, cscli, ...), we do not really care about the scenario, it would be too noisy
 		origin := *decision.Origin
 		if origin == "lists" {
 			origin = origin + ":" + *decision.Scenario
@@ -222,7 +224,7 @@ func (ctx *ipTablesContext) commit() error {
 		} else {
 			set, ok = ctx.ipsets[origin]
 			if !ok {
-				//No set for this origin, skip, as there's nothing to delete
+				// No set for this origin, skip, as there's nothing to delete
 				continue
 			}
 		}
@@ -232,7 +234,6 @@ func (ctx *ipTablesContext) commit() error {
 		log.Debugf("%s", delCmd)
 
 		_, err = tmpFile.WriteString(delCmd)
-
 		if err != nil {
 			log.Errorf("error while writing to temp file : %s", err)
 			continue
@@ -249,9 +250,9 @@ func (ctx *ipTablesContext) commit() error {
 		var set *ipsetcmd.IPSet
 		var ok bool
 
-		if banDuration.Seconds() > 2147483 {
-			log.Warnf("Ban duration too long (%d seconds), maximum for ipset is 2147483, setting duration to 2147482", int(banDuration.Seconds()))
-			banDuration = time.Duration(2147482) * time.Second
+		if banDuration.Seconds() > maxBanSeconds {
+			log.Warnf("Ban duration too long (%d seconds), maximum for ipset is %d, setting duration to %d", int(banDuration.Seconds()), maxBanSeconds, maxBanSeconds-1)
+			banDuration = time.Duration(maxBanSeconds-1) * time.Second
 		}
 
 		origin := *decision.Origin
@@ -279,7 +280,6 @@ func (ctx *ipTablesContext) commit() error {
 				log.Infof("Using %s as set for origin %s", setName, origin)
 
 				set, err = ipsetcmd.NewIPSet(setName)
-
 				if err != nil {
 					log.Errorf("error while creating ipset : %s", err)
 					continue
@@ -292,13 +292,13 @@ func (ctx *ipTablesContext) commit() error {
 				}
 
 				err = set.Create(ipsetcmd.CreateOptions{
-					Family:  family,
-					Timeout: "300",
-					MaxElem: strconv.Itoa(ctx.SetSize),
-					Type:    ctx.SetType,
+					Family:          family,
+					Timeout:         defaultTimeout,
+					MaxElem:         strconv.Itoa(ctx.SetSize),
+					Type:            ctx.SetType,
+					DisableTimeouts: ctx.ipsetDisableTimeouts,
 				})
-
-				//Ignore errors if the set already exists
+				// Ignore errors if the set already exists
 				if err != nil {
 					log.Errorf("error while creating ipset : %s", err)
 					continue
@@ -307,18 +307,22 @@ func (ctx *ipTablesContext) commit() error {
 				ctx.ipsets[origin] = set
 
 				if !ctx.ipsetContentOnly {
-					//Create the rule to use the set
+					// Create the rule to use the set
 					ctx.createRule(set.Name())
 				}
 			}
 		}
 
-		addCmd := fmt.Sprintf("add %s %s timeout %d -exist\n", set.Name(), *decision.Value, int(banDuration.Seconds()))
+		addCmd := ""
+		if ctx.ipsetDisableTimeouts {
+			addCmd = fmt.Sprintf("add %s %s -exist\n", set.Name(), *decision.Value)
+		} else {
+			addCmd = fmt.Sprintf("add %s %s timeout %d -exist\n", set.Name(), *decision.Value, int(banDuration.Seconds()))
+		}
 
 		log.Debugf("%s", addCmd)
 
 		_, err = tmpFile.WriteString(addCmd)
-
 		if err != nil {
 			log.Errorf("error while writing to temp file : %s", err)
 			continue
@@ -337,15 +341,14 @@ func (ctx *ipTablesContext) add(decision *models.Decision) {
 }
 
 func (ctx *ipTablesContext) shutDown() error {
-
-	//Remove rules
+	// Remove rules
 	if !ctx.ipsetContentOnly {
 		ctx.deleteChain()
 	}
 
 	time.Sleep(1 * time.Second)
 
-	//Clean sets
+	// Clean sets
 	for _, set := range ctx.ipsets {
 		if ctx.ipsetContentOnly {
 			err := set.Flush()
@@ -361,7 +364,7 @@ func (ctx *ipTablesContext) shutDown() error {
 	}
 
 	if !ctx.ipsetContentOnly {
-		//In case we are starting, just reset the map
+		// In case we are starting, just reset the map
 		ctx.ipsets = make(map[string]*ipsetcmd.IPSet)
 	}
 


### PR DESCRIPTION
The Ubiquity EdgeRouter 10X does not support creating ipsets with timeouts via its config system.
I added support for disabling the use of timeouts, to be able to use crowdsec-firewall-bouncer on the EdgeRouter in ipset only mode.
Most of the diff is just gofmt having removed blank lines and such in the files I've edited.
I also added a nix devenv shell, to be able to get up and running with the tools needed for development quickly.