### PR TITLE
enhance: Add error to metrics log lines when strconv fails

### DIFF
--- a/pkg/iptables/metrics.go
+++ b/pkg/iptables/metrics.go
@@ -64,7 +64,7 @@ func (ctx *ipTablesContext) collectMetricsIptables(scanner *bufio.Scanner) (map[
 
 			val, err := strconv.Atoi(matches[1])
 			if err != nil {
-				log.Errorf("error while parsing counters : %s", line)
+				log.Errorf("error while parsing counters : %s | %s", line, err)
 				continue
 			}
 
@@ -72,7 +72,7 @@ func (ctx *ipTablesContext) collectMetricsIptables(scanner *bufio.Scanner) (map[
 
 			val, err = strconv.Atoi(matches[2])
 			if err != nil {
-				log.Errorf("error while parsing counters : %s", line)
+				log.Errorf("error while parsing counters : %s | %s", line, err)
 				continue
 			}
 


### PR DESCRIPTION
We dont see what the actual error is so we need more information for #415 