### PR TITLE
update install scripts for ubuntu 25.10

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -79,10 +79,11 @@ jobs:
         sudo -E $(which uv) run pytest ./tests/install/no_crowdsec
         # these need a running crowdsec
         docker run -d --name crowdsec -e CI_TESTING=true -e DISABLE_ONLINE_API=true -e CROWDSEC_BYPASS_DB_VOLUME_CHECK=true -ti crowdsecurity/crowdsec
-        install -m 0755 /dev/stdin /usr/local/bin/cscli <<'EOT'
+        cat >/usr/local/bin/cscli <<'EOT'
         #!/bin/sh
         docker exec crowdsec cscli "$@"
         EOT
+        chmod u+x /usr/local/bin/cscli
         sleep 5
         sudo -E $(which uv) run pytest ./tests/install/with_crowdsec
 

--- a/debian/rules
+++ b/debian/rules
@@ -19,8 +19,10 @@ override_dh_auto_install:
 		PKG="$$BOUNCER-$$BACKEND"; \
 		install -D $$BOUNCER -t "debian/$$PKG/usr/bin/"; \
 		install -D scripts/_bouncer.sh -t "debian/$$PKG/usr/lib/$$PKG/"; \
-		BACKEND=$$BACKEND envsubst '$$BACKEND' < config/$$BOUNCER.yaml | install -D /dev/stdin "debian/$$PKG/etc/crowdsec/bouncers/$$BOUNCER.yaml"; \
-		BIN="/usr/bin/$$BOUNCER" CFG="/etc/crowdsec/bouncers" envsubst '$$BIN $$CFG' < "config/$$BOUNCER.service" | install -D /dev/stdin "debian/$$PKG/etc/systemd/system/$$BOUNCER.service"; \
+		mkdir -p "debian/$$PKG/etc/crowdsec/bouncers"; \
+		(umask 177 && BACKEND=$$BACKEND envsubst '$$BACKEND' < "config/$$BOUNCER.yaml" > "debian/$$PKG/etc/crowdsec/bouncers/$$BOUNCER.yaml"); \
+		mkdir -p "debian/$$PKG/etc/systemd/system"; \
+		BIN="/usr/bin/$$BOUNCER" CFG="/etc/crowdsec/bouncers" envsubst '$$BIN $$CFG' < "config/$$BOUNCER.service" > "debian/$$PKG/etc/systemd/system/$$BOUNCER.service"; \
 		mkdir -p "debian/$$PKG/usr/sbin/"; \
 		ln -s "/usr/bin/$$BOUNCER" "debian/$$PKG/usr/sbin/$$BOUNCER"; \
 	done

--- a/rpm/SPECS/crowdsec-firewall-bouncer.spec
+++ b/rpm/SPECS/crowdsec-firewall-bouncer.spec
@@ -31,20 +31,13 @@ BUILD_VERSION=%{local_version} make
 %install
 rm -rf %{buildroot}
 
-mkdir -p %{buildroot}%{_bindir}
-install -m 755 %{name} %{buildroot}%{_bindir}/%{name}
-# symlink for compatibility with old versions
-
-mkdir -p %{buildroot}/etc/crowdsec/bouncers
-install -m 600 config/%{name}.yaml %{buildroot}/etc/crowdsec/bouncers/%{name}.yaml
-
-mkdir -p %{buildroot}/usr/lib/%{name}
-install -m 600 scripts/_bouncer.sh %{buildroot}/usr/lib/%{name}/_bouncer.sh
+install -m 755 -D %{name} %{buildroot}%{_bindir}/%{name}
+install -m 600 -D config/%{name}.yaml %{buildroot}/etc/crowdsec/bouncers/%{name}.yaml
+install -m 600 -D scripts/_bouncer.sh %{buildroot}/usr/lib/%{name}/_bouncer.sh
 
 mkdir -p %{buildroot}%{_unitdir}
-BIN=%{_bindir}/%{name} CFG=/etc/crowdsec/bouncers envsubst '$BIN $CFG' < config/%{name}.service | install -m 0644 /dev/stdin %{buildroot}%{_unitdir}/%{name}.service
+BIN=%{_bindir}/%{name} CFG=/etc/crowdsec/bouncers envsubst '$BIN $CFG' < config/%{name}.service > %{buildroot}%{_unitdir}/%{name}.service
 
-mkdir -p %{buildroot}%{_presetdir}
 install -D -m 644 %{SOURCE1} %{buildroot}%{_presetdir}/
 
 %clean

--- a/scripts/_bouncer.sh
+++ b/scripts/_bouncer.sh
@@ -121,9 +121,8 @@ set_config_var_value() {
     fi
 
     before=$(cat "$CONFIG")
-    echo "$before" | \
-        env "$varname=$value" envsubst "\$$varname" | \
-        install -m 0600 /dev/stdin "$CONFIG"
+    (umask 177 && echo "$before" | \
+        env "$varname=$value" envsubst "\$$varname" >"$CONFIG")
 }
 
 set_api_key() {


### PR DESCRIPTION
avoid "install /dev/stdin" (broken on ubuntu 25.10)