### PR TITLE
fix(ipset): count members when "Number of entries" is missing from `ipset list`

### DIFF
--- a/pkg/ipsetcmd/ipset.go
+++ b/pkg/ipsetcmd/ipset.go
@@ -225,25 +225,53 @@ func (i *IPSet) Len() int {
 		return 0
 	}
 
-	for _, line := range strings.Split(string(out), "\n") {
+	return parseIPSetLen(string(out))
+}
+
+// parseIPSetLen extracts the number of entries from the output of `ipset list <set>`.
+//
+// Most ipset versions print a "Number of entries:" header line, which we use when
+// present. Some kernels (set protocol v6, e.g. on embedded routers) omit that line
+// entirely, so we fall back to counting the member lines listed after "Members:".
+func parseIPSetLen(out string) int {
+	lines := strings.Split(out, "\n")
+
+	for _, line := range lines {
 		if !strings.Contains(strings.ToLower(line), "number of entries:") {
 			continue
 		}
 
-		fields := strings.Split(line, ":")
+		fields := strings.SplitN(line, ":", 2)
 		if len(fields) != 2 {
 			continue
 		}
 
 		count, err := strconv.Atoi(strings.TrimSpace(fields[1]))
 		if err != nil {
-			return 0
+			continue
 		}
 
 		return count
 	}
 
-	return 0
+	inMembers := false
+	count := 0
+
+	for _, line := range lines {
+		if !inMembers {
+			if strings.TrimSpace(line) == "Members:" {
+				inMembers = true
+			}
+
+			continue
+		}
+
+		if strings.TrimSpace(line) != "" {
+			count++
+		}
+	}
+
+	return count
 }
 
 // Helpers.

--- a/pkg/ipsetcmd/ipset_test.go
+++ b/pkg/ipsetcmd/ipset_test.go
@@ -1,0 +1,68 @@
+package ipsetcmd
+
+import "testing"
+
+func TestParseIPSetLen(t *testing.T) {
+	tests := []struct {
+		name string
+		out  string
+		want int
+	}{
+		{
+			name: "modern ipset with Number of entries header",
+			out: `Name: crowdsec-blacklists-0
+Type: hash:net
+Revision: 7
+Header: family inet hashsize 8192 maxelem 131072 timeout 300
+Size in memory: 769856
+References: 1
+Number of entries: 3
+Members:
+1.2.3.4 timeout 290
+5.6.7.8 timeout 100
+9.10.11.12 timeout 50
+`,
+			want: 3,
+		},
+		{
+			name: "protocol v6 kernel without Number of entries header",
+			out: `Name: crowdsec-blacklists-0
+Type: hash:net
+Revision: 6
+Header: family inet hashsize 8192 maxelem 131072 timeout 300
+Size in memory: 760832
+References: 1
+Members:
+5.11.143.72 timeout 590431
+91.92.42.120 timeout 10034
+20.64.105.88 timeout 6299
+`,
+			want: 3,
+		},
+		{
+			name: "empty set without header",
+			out: `Name: crowdsec-blacklists-1
+Type: hash:net
+Revision: 6
+Header: family inet hashsize 1024 maxelem 131072 timeout 300
+Size in memory: 4192
+References: 1
+Members:
+`,
+			want: 0,
+		},
+		{
+			name: "garbage output",
+			out:  "some error happened\n",
+			want: 0,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := parseIPSetLen(tc.out); got != tc.want {
+				t.Errorf("parseIPSetLen() = %d, want %d", got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
  ## What
  
  `IPSet.Len()` returns the correct entry count on kernels whose `ipset list`
  output omits the `Number of entries:` header line, fixing the
  `fw_bouncer_banned_ips` metric reporting `0` on those systems.
  
  ## Why / root cause
  
  `IPSet.Len()` parsed **only** the `Number of entries:` line of `ipset list`:
  
```go
  for _, line := range strings.Split(string(out), "\n") {
      if !strings.Contains(strings.ToLower(line), "number of entries:") {
          continue
      }   
      ...
  }   
  return 0
```  

  That line is only printed by the newer set protocol. On kernels that expose
  set protocol v6 (common on embedded systems — e.g. Keenetic routers
  running Entware), ipset list produces no such line:

  Name: crowdsec-blacklists-0
  Type: hash:net
  Revision: 6
  Header: family inet hashsize 8192 maxelem 131072 timeout 300
  Size in memory: 760832
  References: 1
  Members:
  5.11.143.72 timeout 590431
  ...

  Len() never matches and falls through to return 0. Because the
  fw_bouncer_banned_ips gauge is set directly from set.Len()
  (pkg/iptables/metrics.go), the metric reports 0 even when the ipsets
  hold tens of thousands of entries. The fw_bouncer_dropped_* and
  lapi_requests_* metrics are parsed differently and were unaffected.

  What changed

  - Extracted the parsing into a pure parseIPSetLen() helper.
  - Kept the fast path using Number of entries: when present.
  - Added a fallback that counts the member lines after the Members:
  header when that line is absent.

  Testing

  - go test ./pkg/ipsetcmd/ — new table test TestParseIPSetLen covers a
  modern (Number of entries:) output, a protocol-v6 output without that
  line, an empty set, and garbage input.
  - Built for linux/arm64 and deployed on a Keenetic router (set protocol
  v6): fw_bouncer_banned_ips now matches the real ipset sizes
  (e.g. 19255 for the CAPI set) instead of 0.

  Notes

  No behaviour change on kernels that already emit Number of entries: — the
  fast path is unchanged; the fallback only triggers when the line is absent.